### PR TITLE
Added the hability to create default styles for UI elements

### DIFF
--- a/lib/teacup/view.rb
+++ b/lib/teacup/view.rb
@@ -70,6 +70,13 @@ module Teacup
     #
     # @param Hash  the properties to set.
     def style(properties)
+
+      self.class.ancestors.each do |ancestor|
+        if default_properties = stylesheet.query(ancestor)
+          properties = default_properties.merge properties
+        end
+      end
+      
       clean_properties! properties
 
       properties.each do |key, value|


### PR DESCRIPTION
Defining a style for a UIView subclass sets a default style for that class:

``` Ruby
Teacup::Stylesheet.new(:IPhone) do
  style UIButton,
    backgroundColor: UIColor.greenColor
end
```

Now all UIButtons will have green background by default.
