### PR TITLE
Fixes issue #36 and adds more dummy methods

### DIFF
--- a/lib/dummy.rb
+++ b/lib/dummy.rb
@@ -3,6 +3,15 @@ class DummyView < UIView
 
   def dummy
     setFrame(nil)
+    setOpaque(nil)
+  end
+
+end
+
+class DummyScrollView < UIScrollView
+
+  def dummy
+    setScrollEnabled(nil)
   end
 
 end

--- a/lib/dummy.rb
+++ b/lib/dummy.rb
@@ -14,6 +14,11 @@ class DummyLayer < CALayer
     setTransform(nil)
     setMasksToBounds(nil)
     setShadowOffset(nil)
+    setShadowOpacity(nil)
+    setShadowRadius(nil)
+    setShadowOffset(nil)
+    setShadowColor(nil)
+    setShadowPath(nil)
   end
 
 end

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -141,18 +141,24 @@ class UIView
     end
 
     properties.each do |key, value|
-      assign = :"#{key}="
-      setter = ('set' + key.to_s.sub(/^./) {|c| c.capitalize}).to_sym
+      if key =~ /^set[A-Z]/
+        assign = nil
+        setter = key.to_s + ':'
+      else
+        assign = :"#{key}="
+        setter = 'set' + key.to_s.sub(/^./) {|c| c.capitalize} + ':'
+      end
+
       if key == :title && UIButton === self
         setTitle(value, forState: UIControlStateNormal)
-      elsif respond_to?(assign)
+      elsif assign and respond_to?(assign)
         # puts "Setting #{key} = #{value.inspect}"
         send(assign, value)
-      elsif respond_to?(setter)
+      elsif respondsToSelector(setter)
         # puts "Calling self(#{key}, #{value.inspect})"
         send(setter, value)
       else
-        puts "Teacup WARN: Can't apply #{key} to #{self.inspect}"
+        puts "Teacup WARN: Can't apply #{setter.inspect}#{assign and " or " + assign.inspect or ""} to #{self.inspect}"
       end
     end
     self.setNeedsDisplay


### PR DESCRIPTION
Using `respondsToSelector` instead of `respond_to?` fixes the bug that some methods (might have something to do with a protocol) return `false` for `respond_to?(selector)` but (correctly) return `true` for `respondsToSelector(selector)`

And dummy methods, since those continue to be found and needed.
