### PR TITLE
Gemifies teacup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source :rubygems
 
+gem 'teacup', :path => '.'
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    teacup (0.0.1)
+    teacup (0.2.5)
       rake
 
 GEM

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2012, rubymotion community
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Teacup Project.

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,11 @@
 $:.unshift('/Library/RubyMotion/lib')
 require 'motion/project'
-
-
-dirs = ['lib', 'app']
+require 'bundler'
+Bundler.require
 
 
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
-  app.files = dirs.map{|d| Dir.glob(File.join(app.project_dir, "#{d}/**/*.rb")) }.flatten
   app.name = 'teacup'
   app.identifier = 'com.rubymotion.teacup'
 end

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -4,8 +4,8 @@ class AppDelegate
     application.setStatusBarStyle(UIStatusBarStyleBlackTranslucent)
 
     @window = UIWindow.alloc.initWithFrame(UIScreen.mainScreen.bounds)
-    @window.rootViewController = FirstController.new
-    @window.rootViewController.wantsFullScreenLayout = true
+    # @window.rootViewController = FirstController.new
+    # @window.rootViewController.wantsFullScreenLayout = true
     @window.makeKeyAndVisible
 
     true

--- a/app/controllers/first_controller.rb
+++ b/app/controllers/first_controller.rb
@@ -4,7 +4,7 @@ class FirstController < UIViewController
   stylesheet :first
 
   layout :root do
-    subview(UIView, :background) do
+    subview(CustomView, :background) do
       @welcome = subview(UILabel, :welcome)
       subview(UILabel, :footer)
       @button = subview(UIButton.buttonWithType(UIButtonTypeRoundedRect), :next_message)

--- a/app/styles/main_styles.rb
+++ b/app/styles/main_styles.rb
@@ -35,9 +35,21 @@ Teacup::Stylesheet.new(:first) do
     textColor:  UIColor.blueColor,
   })
 
+  style CustomView,
+    # for testing how styles override (this gets overridden by any property in
+    # a style block, regardless of whether it is in an orientation style)
+    portrait: {
+      alpha: 0.75
+    },
+    landscape: {
+      alpha: 0.75
+    }
+
   style(:background, {
+    alpha: 0.5,
     left: 10,
     top: 30,
+    backgroundColor:  UIColor.blackColor,
 
     portrait: {
       width:  300,
@@ -48,6 +60,7 @@ Teacup::Stylesheet.new(:first) do
     landscape: {
       width:  460,
       height: 280,
+      alpha: 0.8,
       backgroundColor:  UIColor.lightGrayColor,
     },
   })

--- a/app/views/custom_view.rb
+++ b/app/views/custom_view.rb
@@ -1,0 +1,4 @@
+
+class CustomView < UIView
+  # not very custom, is it!?
+end

--- a/lib/dummy.rb
+++ b/lib/dummy.rb
@@ -3,6 +3,15 @@ class DummyView < UIView
 
   def dummy
     setFrame(nil)
+    setOpaque(nil)
+  end
+
+end
+
+class DummyScrollView < UIScrollView
+
+  def dummy
+    setScrollEnabled(nil)
   end
 
 end

--- a/lib/dummy.rb
+++ b/lib/dummy.rb
@@ -14,6 +14,11 @@ class DummyLayer < CALayer
     setTransform(nil)
     setMasksToBounds(nil)
     setShadowOffset(nil)
+    setShadowOpacity(nil)
+    setShadowRadius(nil)
+    setShadowOffset(nil)
+    setShadowColor(nil)
+    setShadowPath(nil)
   end
 
 end

--- a/lib/dummy.rb
+++ b/lib/dummy.rb
@@ -8,6 +8,7 @@ class DummyView < UIView
 
 end
 
+
 class DummyScrollView < UIScrollView
 
   def dummy
@@ -15,6 +16,16 @@ class DummyScrollView < UIScrollView
   end
 
 end
+
+
+class DummyLabel < UILabel
+
+  def dummy
+    setAdjustsFontSizeToFitWidth(nil)
+  end
+
+end
+
 
 class DummyLayer < CALayer
 

--- a/lib/teacup.rb
+++ b/lib/teacup.rb
@@ -7,5 +7,5 @@ Motion::Project::App.setup do |app|
   Dir.glob(File.join(File.dirname(__FILE__), 'teacup/**/*.rb')).each do |file|
     app.files.unshift(file)
   end
-  app.files.unshift('dummy.rb')
+  app.files.unshift(File.join(File.dirname(__FILE__), 'dummy.rb'))
 end

--- a/lib/teacup.rb
+++ b/lib/teacup.rb
@@ -1,0 +1,10 @@
+unless defined?(Motion::Project::Config)
+  raise "This file (teacup) must be required within a RubyMotion project Rakefile."
+end
+
+
+Motion::Project::App.setup do |app|
+  Dir.glob(File.join(File.dirname(__FILE__), 'teacup/**/*.rb')).each do |file|
+    app.files.unshift(file)
+  end
+end

--- a/lib/teacup.rb
+++ b/lib/teacup.rb
@@ -4,7 +4,7 @@ end
 
 
 Motion::Project::App.setup do |app|
-  Dir.glob(File.join(File.dirname(__FILE__), 'teacup/**/*.rb')).each do |file|
+  Dir.glob(File.join(File.dirname(__FILE__), 'teacup/**/*.rb')).reverse.each do |file|
     app.files.unshift(file)
   end
   app.files.push(File.join(File.dirname(__FILE__), 'dummy.rb'))

--- a/lib/teacup.rb
+++ b/lib/teacup.rb
@@ -7,5 +7,5 @@ Motion::Project::App.setup do |app|
   Dir.glob(File.join(File.dirname(__FILE__), 'teacup/**/*.rb')).each do |file|
     app.files.unshift(file)
   end
-  app.files.unshift(File.join(File.dirname(__FILE__), 'dummy.rb'))
+  app.files.push(File.join(File.dirname(__FILE__), 'dummy.rb'))
 end

--- a/lib/teacup.rb
+++ b/lib/teacup.rb
@@ -7,4 +7,5 @@ Motion::Project::App.setup do |app|
   Dir.glob(File.join(File.dirname(__FILE__), 'teacup/**/*.rb')).each do |file|
     app.files.unshift(file)
   end
+  app.files.unshift('dummy.rb')
 end

--- a/lib/teacup/contributors.rb
+++ b/lib/teacup/contributors.rb
@@ -1,5 +1,0 @@
-module Teacup
-
-  CONTRIBUTORS = ['Chris Clarke', 'Colin Thomas-Arnold', 'Conrad Irwin', 'Mark Villacampa']
-
-end

--- a/lib/teacup/merge_defaults.rb
+++ b/lib/teacup/merge_defaults.rb
@@ -1,4 +1,3 @@
-
 module Teacup
   module_function
 
@@ -11,11 +10,6 @@ module Teacup
   # creating a new Hash.  Usually used with `merge_defaults!`, which merges values
   # from `right` into `left`.
   def merge_defaults(left, right, target={})
-    if target == left
-    elsif target == right
-    else
-    end
-
     if target != left
       left.each do |key, value|
         if target.has_key? key and value.is_a?(Hash) and target[key].is_a?(Hash)

--- a/lib/teacup/merge_defaults.rb
+++ b/lib/teacup/merge_defaults.rb
@@ -1,0 +1,51 @@
+
+module Teacup
+  module_function
+
+  # Merges two Hashes.  This is similar to `Hash#merge`, except the values will
+  # be merged recursively (aka deep merge) when both values for a key are
+  # Hashes, and values for the *left* argument are preferred over values on the
+  # right.
+  #
+  # If you pass in a third argument, it will be acted upon directly instead of
+  # creating a new Hash.  Usually used with `merge_defaults!`, which merges values
+  # from `right` into `left`.
+  def merge_defaults(left, right, target={})
+    if target == left
+    elsif target == right
+    else
+    end
+
+    if target != left
+      left.each do |key, value|
+        if target.has_key? key and value.is_a?(Hash) and target[key].is_a?(Hash)
+          target[key] = Teacup::merge_defaults(target[key], value)
+        else
+          if value.is_a?(Hash)
+            # make a copy of the Hash
+            value = Teacup::merge_defaults!({}, value)
+          end
+          target[key] = value
+        end
+      end
+    end
+
+    right.each do |key, value|
+      if not target.has_key? key
+        if value.is_a?(Hash)
+          # make a copy of the Hash
+          value = Teacup::merge_defaults!({}, value)
+        end
+        target[key] = value
+      elsif value.is_a?(Hash) and left[key].is_a?(Hash)
+        target[key] = Teacup::merge_defaults(left[key], value, (left==target ? left[key] : {}))
+      end
+    end
+    target
+  end
+
+  # modifies left by passing it in as the `target`.
+  def merge_defaults!(left, right)
+    Teacup::merge_defaults(left, right, left)
+  end
+end

--- a/lib/teacup/style.rb
+++ b/lib/teacup/style.rb
@@ -1,0 +1,85 @@
+module Teacup
+  # The Style class is where the precedence rules are applied.  A Style can
+  # query the Stylesheet that created it to look up other styles (for
+  # `extends:`) and to import other Stylesheets.  If it is handed a target (e.g.
+  # a `UIView` instance) and orientation, it will merge those in appropriately
+  # as well.
+  class Style < Hash
+    attr_accessor :stylename
+    attr_accessor :stylesheet
+
+    Orientations = [:portrait, :upside_up, :upside_down, :landscape, :landscape_left, :landscape_right]
+    Overrides = {
+      UIInterfaceOrientationPortrait => [:portrait, :upside_up],
+      UIInterfaceOrientationPortraitUpsideDown => [:portrait, :upside_down],
+      UIInterfaceOrientationLandscapeLeft => [:landscape, :landscape_left],
+      UIInterfaceOrientationLandscapeRight => [:landscape, :landscape_right],
+    }
+
+    # A hash of orientation => true/false.  true means the orientation is
+    # supported.
+    def supports
+      @supports ||= {}
+    end
+
+    def supports? orientation_key
+      supports.has_key? orientation_key
+    end
+
+    def build(target=nil, orientation=nil, seen={})
+      properties = Style.new.update(self)
+      properties.stylename = self.stylename
+      properties.stylesheet = self.stylesheet
+
+      # first, move orientation settings into properties "base" level.
+      if orientation
+        Overrides[orientation].each do |orientation_key|
+          if override = properties.delete(orientation_key)
+            # override is first, so it takes precedence
+            Teacup::merge_defaults override, properties, properties
+            properties.supports[orientation_key] = true
+          end
+        end
+      end
+
+      # delete all of them from `properties`
+      Orientations.each do |orientation_key|
+        if properties.delete(orientation_key)
+          properties.supports[orientation_key] = true
+        end
+      end
+
+      # now we can merge extends, and importing.  before merging, these will go
+      # through the same process that we just finished on the local style
+      if stylesheet
+        stylesheet.imported_stylesheets.reverse.each do |stylesheet|
+          imported_properties = stylesheet.query(self.stylename, target, orientation, seen)
+          Teacup::merge_defaults! properties, imported_properties
+        end
+
+        if also_includes = properties.delete(:extends)
+          also_includes = [also_includes] unless also_includes.is_a? Array
+
+          # turn style names into Hashes by querying them on the stylesheet
+          # (this does not pass `seen`, because this is a new query)
+          also_includes.each do |also_include|
+            extended_properties = stylesheet.query(also_include, target, orientation)
+            Teacup::merge_defaults! properties, extended_properties
+          end
+        end
+
+        # if we know the class of the target, we can apply styles via class
+        # inheritance.  We do not pass `target` in this case.
+        if target
+          target.class.ancestors.each do |ancestor|
+            extended_properties = stylesheet.query(ancestor, nil, orientation)
+            Teacup::merge_defaults!(properties, extended_properties)
+          end
+        end
+      end
+
+      properties
+    end
+
+  end
+end

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -235,7 +235,7 @@ module Teacup
       imported.map do |name_or_stylesheet|
         if Teacup::Stylesheet === name_or_stylesheet
           name_or_stylesheet
-        elsif Teacup::Stylesheet.stylesheets.key? name_or_stylesheet
+        elsif Teacup::Stylesheet.stylesheets.has_key? name_or_stylesheet
           Teacup::Stylesheet.stylesheets[name_or_stylesheet]
         else
           raise "Teacup tried to import Stylesheet '#{name_or_stylesheet.inspect}' into Stylesheet[#{self.name}], but it didn't exist"

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -153,10 +153,11 @@ module Teacup
       this_rule = properties_for(stylename)
 
       if also_include = this_rule.delete(:extends)
-        query(also_include).update(this_rule)
-      else
-        this_rule
+        # we stick the extended Hash onto 'extends', which will get picked
+        # up by UIView#style, which handles precedence.
+        this_rule[:extends] = query(also_include)
       end
+      this_rule
     end
 
     # Add a set of properties for a given stylename or multiple stylenames.

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -208,6 +208,10 @@ module Teacup
     def properties_for(stylename, so_far={}, seen={})
       return so_far if seen[self]
 
+      # the block handed to Stylesheet#new is not run immediately - it is run
+      # the first time the stylesheet is queried.  This fixes bugs related to
+      # some resources (fonts) not available when the application is first
+      # started.
       if @block
         instance_eval &@block
         @block = nil

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -152,10 +152,11 @@ module Teacup
     def query(stylename)
       this_rule = properties_for(stylename)
 
-      if also_include = this_rule.delete(:extends)
+      if also_includes = this_rule.delete(:extends)
+        also_includes = [also_includes] unless also_includes.is_a? Array
         # we stick the extended Hash onto 'extends', which will get picked
         # up by UIView#style, which handles precedence.
-        this_rule[:extends] = query(also_include)
+        this_rule[:extends] = also_includes.map {|also_include| query(also_include) }
       end
       this_rule
     end

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -243,7 +243,7 @@ module Teacup
         elsif Teacup::Stylesheet.stylesheets.has_key? name_or_stylesheet
           Teacup::Stylesheet.stylesheets[name_or_stylesheet]
         else
-          raise "Teacup tried to import Stylesheet '#{name_or_stylesheet.inspect}' into Stylesheet[#{self.name}], but it didn't exist"
+          raise "Teacup tried to import Stylesheet #{name_or_stylesheet.inspect} into Stylesheet[#{self.name.inspect}], but it didn't exist"
         end
       end
     end

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -173,7 +173,7 @@ module Teacup
     #       title: "Continue!",
     #       top: 50
     #   end
-    def style(*queries, &block)
+    def style(*queries)
       properties = {}
 
       # if the last argument is a Hash, include it
@@ -181,7 +181,7 @@ module Teacup
 
       # iterate over the style names and assign properties
       queries.each do |stylename|
-        styles[stylename].update(properties)
+        Teacup::merge_defaults(properties, styles[stylename], styles[stylename])
       end
     end
 
@@ -223,7 +223,7 @@ module Teacup
         stylesheet.properties_for(stylename, so_far, seen)
       end
 
-      so_far.update(styles[stylename])
+      Teacup::merge_defaults styles[stylename], so_far, so_far
     end
 
     # The list of Stylesheets or names that have been imported into this one.

--- a/lib/teacup/version.rb
+++ b/lib/teacup/version.rb
@@ -1,5 +1,5 @@
 module Teacup
 
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 
 end

--- a/lib/teacup/version.rb
+++ b/lib/teacup/version.rb
@@ -1,5 +1,5 @@
 module Teacup
 
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 
 end

--- a/lib/teacup/version.rb
+++ b/lib/teacup/version.rb
@@ -1,5 +1,5 @@
 module Teacup
 
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 
 end

--- a/lib/teacup/version.rb
+++ b/lib/teacup/version.rb
@@ -1,5 +1,5 @@
 module Teacup
 
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 
 end

--- a/lib/teacup/version.rb
+++ b/lib/teacup/version.rb
@@ -1,5 +1,5 @@
 module Teacup
 
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 
 end

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -148,19 +148,14 @@ class UIView
     self.setNeedsDisplay
   end
 
-  # merges two Hashs.  When the value of the "lesser" Hash is a Hash, it will be
-  # merged into the "greater" Hash, or it will be assigned if the value is True
-  # or not assigned at all.
+  # merges two Hashes.  This is similar to `Hash#update`, except the values will
+  # be merged recursively (aka deep merge) when both values for a key are Hashes
   def teacup_merge properties, extended_properties
     extended_properties.each do |key, value|
       if not properties.has_key? key
         properties[key] = value
-      elsif Hash === value
-        if Hash === properties[key]
-          teacup_merge properties[key], value
-        elsif TrueClass === properties[key]
-          properties[key] = value
-        end
+      elsif Hash === value and Hash === properties[key]
+        teacup_merge properties[key], value
       end
     end
     properties

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -96,14 +96,14 @@ class UIView
     # check for `:extends` and merge those in
     while extended_properties = properties.delete(:extends)
       clean_properties extended_properties, orientation
-      teacup_merge properties, extended_properties
+      Teacup::merge_defaults!(properties, extended_properties)
     end
 
     if stylesheet
       self.class.ancestors.each do |ancestor|
         if extended_properties = stylesheet.query(ancestor)
           clean_properties extended_properties, orientation
-          teacup_merge properties, extended_properties
+          Teacup::merge_defaults!(properties, extended_properties)
         end
       end
     end
@@ -146,19 +146,6 @@ class UIView
       end
     end
     self.setNeedsDisplay
-  end
-
-  # merges two Hashes.  This is similar to `Hash#update`, except the values will
-  # be merged recursively (aka deep merge) when both values for a key are Hashes
-  def teacup_merge properties, extended_properties
-    extended_properties.each do |key, value|
-      if not properties.has_key? key
-        properties[key] = value
-      elsif Hash === value and Hash === properties[key]
-        teacup_merge properties[key], value
-      end
-    end
-    properties
   end
 
   # Merge definitions for 'frame' and orientation styles into one.

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -90,10 +90,10 @@ class UIView
         assign = :"#{key}="
         setter = ('set' + key.to_s.sub(/^./) {|c| c.capitalize}).to_sym
         if layer.respond_to?(assign)
-          NSLog "Setting layer.#{key} = #{value.inspect}"
+          # NSLog "Setting layer.#{key} = #{value.inspect}"
           layer.send(assign, value)
         elsif layer.respond_to?(setter)
-          NSLog "Calling layer(#{key}, #{value.inspect})"
+          # NSLog "Calling layer(#{key}, #{value.inspect})"
           layer.send(setter, value)
         else
           NSLog "Teacup WARN: Can't apply #{key} to #{self.layer.inspect}"
@@ -111,17 +111,17 @@ class UIView
       end
 
       if key == :title && UIButton === self
-        NSLog "Setting #{key} = #{value.inspect}, forState:UIControlStateNormal"
+        # NSLog "Setting #{key} = #{value.inspect}, forState:UIControlStateNormal"
         setTitle(value, forState: UIControlStateNormal)
       # elsif key == :normal && UIButton === self
       #   setImage(value, forState: UIControlStateNormal)
       # elsif key == :highlighted && UIButton === self
       #   setImage(value, forState: UIControlStateHighlighted)
       elsif assign and respond_to?(assign)
-        NSLog "Setting #{key} = #{value.inspect}"
+        # NSLog "Setting #{key} = #{value.inspect}"
         send(assign, value)
       elsif respondsToSelector(setter)
-        NSLog "Calling self(#{key}, #{value.inspect})"
+        # NSLog "Calling self(#{key}, #{value.inspect})"
         send(setter, value)
       else
         NSLog "Teacup WARN: Can't apply #{setter.inspect}#{assign and " or " + assign.inspect or ""} to #{self.inspect}"

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -85,44 +85,22 @@ class UIView
   #
   # @param Hash  the properties to set.
   def style(properties, orientation=nil)
+    # the order of assigning to properties is muy importante here.  We want
+    # the orientation styles to override what is in the "default" styles, but
+    # when we import styles from ancestors, we don't want those to override what
+    # we already set.
+
+    # convert top/left/width/height and orientation properties
+    clean_properties properties, orientation
+
     if stylesheet
       self.class.ancestors.each do |ancestor|
         if default_properties = stylesheet.query(ancestor)
+          clean_properties default_properties, orientation
           properties = default_properties.merge properties
         end
       end
     end
-
-    # orientation-specific properties
-    portrait = properties.delete(:portrait)
-    upside_up = properties.delete(:upside_up)
-    upside_down = properties.delete(:upside_down)
-
-    landscape = properties.delete(:landscape)
-    landscape_left = properties.delete(:landscape_left)
-    landscape_right = properties.delete(:landscape_right)
-
-    if orientation.nil?
-      orientation = UIApplication.sharedApplication.statusBarOrientation
-    end
-
-    case orientation
-    when UIInterfaceOrientationPortrait
-      properties = portrait.update(properties) if Hash === portrait
-      properties = upside_up.update(properties) if Hash === upside_up
-    when UIInterfaceOrientationPortraitUpsideDown
-      properties = portrait.update(properties) if Hash === portrait
-      properties = upside_down.update(properties) if Hash === upside_down
-    when UIInterfaceOrientationLandscapeLeft
-      properties = landscape.update(properties) if Hash === landscape
-      properties = landscape_left.update(properties) if Hash === landscape_left
-    when UIInterfaceOrientationLandscapeRight
-      properties = landscape.update(properties) if Hash === landscape
-      properties = landscape_right.update(properties) if Hash === landscape_right
-    end
-
-    # convert top/left/width/height to frame values
-    clean_properties properties
 
     if layer_properties = properties.delete(:layer)
       layer_properties.each do |key, value|
@@ -164,7 +142,7 @@ class UIView
     self.setNeedsDisplay
   end
 
-  # merge definitions for 'frame' into one.
+  # Merge definitions for 'frame' and orientation styles into one.
   #
   # To support 'extends' more nicely it's convenient to split left, top, width
   # and height out of frame. Unfortunately that means we have to write ugly
@@ -174,17 +152,51 @@ class UIView
   #
   # @param Hash
   # @return Hash
-  def clean_properties(properties)
-    return unless [:frame, :left, :top, :width, :height].any?(&properties.method(:key?))
+  def clean_properties(properties, orientation=nil)
+    if [:portrait, :upside_up, :upside_down,
+        :landscape, :landscape_left, :landscape_right
+        ].any?(&properties.method(:has_key?))
+      # orientation-specific properties
+      portrait = properties.delete(:portrait)
+      upside_up = properties.delete(:upside_up)
+      upside_down = properties.delete(:upside_down)
 
-    frame = properties.delete(:frame) || self.frame
+      landscape = properties.delete(:landscape)
+      landscape_left = properties.delete(:landscape_left)
+      landscape_right = properties.delete(:landscape_right)
 
-    frame[0][0] = properties.delete(:left) || frame[0][0]
-    frame[0][1] = properties.delete(:top) || frame[0][1]
-    frame[1][0] = properties.delete(:width) || frame[1][0]
-    frame[1][1] = properties.delete(:height) || frame[1][1]
+      if orientation.nil?
+        orientation = UIApplication.sharedApplication.statusBarOrientation
+      end
 
-    properties[:frame] = frame
+      case orientation
+      when UIInterfaceOrientationPortrait
+        properties.update(portrait) if Hash === portrait
+        properties.update(upside_up) if Hash === upside_up
+      when UIInterfaceOrientationPortraitUpsideDown
+        properties.update(portrait) if Hash === portrait
+        properties.update(upside_down) if Hash === upside_down
+      when UIInterfaceOrientationLandscapeLeft
+        properties.update(landscape) if Hash === landscape
+        properties.update(landscape_left) if Hash === landscape_left
+      when UIInterfaceOrientationLandscapeRight
+        properties.update(landscape) if Hash === landscape
+        properties.update(landscape_right) if Hash === landscape_right
+      end
+    end
+
+    # this has to come *after* orientation merges
+    if [:frame, :left, :top, :width, :height].any?(&properties.method(:has_key?))
+      frame = properties.delete(:frame) || self.frame
+
+      frame[0][0] = properties.delete(:left) || frame[0][0]
+      frame[0][1] = properties.delete(:top) || frame[0][1]
+      frame[1][0] = properties.delete(:width) || frame[1][0]
+      frame[1][1] = properties.delete(:height) || frame[1][1]
+
+      properties[:frame] = frame
+    end
+
     properties
   end
 

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -90,10 +90,10 @@ class UIView
         assign = :"#{key}="
         setter = ('set' + key.to_s.sub(/^./) {|c| c.capitalize}).to_sym
         if layer.respond_to?(assign)
-          # NSLog "Setting layer.#{key} = #{value.inspect}"
+          NSLog "Setting layer.#{key} = #{value.inspect}"
           layer.send(assign, value)
         elsif layer.respond_to?(setter)
-          # NSLog "Calling layer(#{key}, #{value.inspect})"
+          NSLog "Calling layer(#{key}, #{value.inspect})"
           layer.send(setter, value)
         else
           NSLog "Teacup WARN: Can't apply #{key} to #{self.layer.inspect}"
@@ -111,17 +111,17 @@ class UIView
       end
 
       if key == :title && UIButton === self
-        # NSLog "Setting #{key} = #{value.inspect}, forState:UIControlStateNormal"
+        NSLog "Setting #{key} = #{value.inspect}, forState:UIControlStateNormal"
         setTitle(value, forState: UIControlStateNormal)
       # elsif key == :normal && UIButton === self
       #   setImage(value, forState: UIControlStateNormal)
       # elsif key == :highlighted && UIButton === self
       #   setImage(value, forState: UIControlStateHighlighted)
       elsif assign and respond_to?(assign)
-        # NSLog "Setting #{key} = #{value.inspect}"
+        NSLog "Setting #{key} = #{value.inspect}"
         send(assign, value)
       elsif respondsToSelector(setter)
-        # NSLog "Calling self(#{key}, #{value.inspect})"
+        NSLog "Calling self(#{key}, #{value.inspect})"
         send(setter, value)
       else
         NSLog "Teacup WARN: Can't apply #{setter.inspect}#{assign and " or " + assign.inspect or ""} to #{self.inspect}"

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -90,13 +90,13 @@ class UIView
         assign = :"#{key}="
         setter = ('set' + key.to_s.sub(/^./) {|c| c.capitalize}).to_sym
         if layer.respond_to?(assign)
-          # puts "Setting layer.#{key} = #{value.inspect}"
+          NSLog "Setting layer.#{key} = #{value.inspect}"
           layer.send(assign, value)
         elsif layer.respond_to?(setter)
-          # puts "Calling layer(#{key}, #{value.inspect})"
+          NSLog "Calling layer(#{key}, #{value.inspect})"
           layer.send(setter, value)
       else
-        puts "Teacup WARN: Can't apply #{key} to #{self.layer.inspect}"
+        NSLog "Teacup WARN: Can't apply #{key} to #{self.layer.inspect}"
         end
       end
     end
@@ -111,15 +111,16 @@ class UIView
       end
 
       if key == :title && UIButton === self
+        NSLog "Setting #{key} = #{value.inspect}, forState:UIControlStateNormal"
         setTitle(value, forState: UIControlStateNormal)
       elsif assign and respond_to?(assign)
-        # puts "Setting #{key} = #{value.inspect}"
+        NSLog "Setting #{key} = #{value.inspect}"
         send(assign, value)
       elsif respondsToSelector(setter)
-        # puts "Calling self(#{key}, #{value.inspect})"
+        NSLog "Calling self(#{key}, #{value.inspect})"
         send(setter, value)
       else
-        puts "Teacup WARN: Can't apply #{setter.inspect}#{assign and " or " + assign.inspect or ""} to #{self.inspect}"
+        NSLog "Teacup WARN: Can't apply #{setter.inspect}#{assign and " or " + assign.inspect or ""} to #{self.inspect}"
       end
     end
     self.setNeedsDisplay

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -93,11 +93,17 @@ class UIView
     # convert top/left/width/height and orientation properties
     clean_properties properties, orientation
 
+    # check for `:extends` and merge those in
+    while extended_properties = properties.delete(:extends)
+      clean_properties extended_properties, orientation
+      teacup_merge properties, extended_properties
+    end
+
     if stylesheet
       self.class.ancestors.each do |ancestor|
-        if default_properties = stylesheet.query(ancestor)
-          clean_properties default_properties, orientation
-          properties = default_properties.merge properties
+        if extended_properties = stylesheet.query(ancestor)
+          clean_properties extended_properties, orientation
+          teacup_merge properties, extended_properties
         end
       end
     end
@@ -140,6 +146,11 @@ class UIView
       end
     end
     self.setNeedsDisplay
+  end
+
+  # merges two Hashs - it's a deep_merge.
+  def teacup_merge properties, extended_properties
+    extended_properties.update(properties)
   end
 
   # Merge definitions for 'frame' and orientation styles into one.

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -141,18 +141,24 @@ class UIView
     end
 
     properties.each do |key, value|
-      assign = :"#{key}="
-      setter = ('set' + key.to_s.sub(/^./) {|c| c.capitalize}).to_sym
+      if key =~ /^set[A-Z]/
+        assign = nil
+        setter = key.to_s + ':'
+      else
+        assign = :"#{key}="
+        setter = 'set' + key.to_s.sub(/^./) {|c| c.capitalize} + ':'
+      end
+
       if key == :title && UIButton === self
         setTitle(value, forState: UIControlStateNormal)
-      elsif respond_to?(assign)
+      elsif assign and respond_to?(assign)
         # puts "Setting #{key} = #{value.inspect}"
         send(assign, value)
-      elsif respond_to?(setter)
+      elsif respondsToSelector(setter)
         # puts "Calling self(#{key}, #{value.inspect})"
         send(setter, value)
       else
-        puts "Teacup WARN: Can't apply #{key} to #{self.inspect}"
+        puts "Teacup WARN: Can't apply #{setter.inspect}#{assign and " or " + assign.inspect or ""} to #{self.inspect}"
       end
     end
     self.setNeedsDisplay

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -95,8 +95,8 @@ class UIView
         elsif layer.respond_to?(setter)
           # NSLog "Calling layer(#{key}, #{value.inspect})"
           layer.send(setter, value)
-      else
-        NSLog "Teacup WARN: Can't apply #{key} to #{self.layer.inspect}"
+        else
+          NSLog "Teacup WARN: Can't apply #{key} to #{self.layer.inspect}"
         end
       end
     end

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -108,17 +108,17 @@ class UIView
 
     case orientation
     when UIInterfaceOrientationPortrait
-      properties.update(portrait) if Hash === portrait
-      properties.update(upside_up) if Hash === upside_up
+      properties = portrait.update(properties) if Hash === portrait
+      properties = upside_up.update(properties) if Hash === upside_up
     when UIInterfaceOrientationPortraitUpsideDown
-      properties.update(portrait) if Hash === portrait
-      properties.update(upside_down) if Hash === upside_down
+      properties = portrait.update(properties) if Hash === portrait
+      properties = upside_down.update(properties) if Hash === upside_down
     when UIInterfaceOrientationLandscapeLeft
-      properties.update(landscape) if Hash === landscape
-      properties.update(landscape_left) if Hash === landscape_left
+      properties = landscape.update(properties) if Hash === landscape
+      properties = landscape_left.update(properties) if Hash === landscape_left
     when UIInterfaceOrientationLandscapeRight
-      properties.update(landscape) if Hash === landscape
-      properties.update(landscape_right) if Hash === landscape_right
+      properties = landscape.update(properties) if Hash === landscape
+      properties = landscape_right.update(properties) if Hash === landscape_right
     end
 
     # convert top/left/width/height to frame values

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -148,9 +148,22 @@ class UIView
     self.setNeedsDisplay
   end
 
-  # merges two Hashs - it's a deep_merge.
+  # merges two Hashs.  When the value of the "lesser" Hash is a Hash, it will be
+  # merged into the "greater" Hash, or it will be assigned if the value is True
+  # or not assigned at all.
   def teacup_merge properties, extended_properties
-    extended_properties.update(properties)
+    extended_properties.each do |key, value|
+      if not properties.has_key? key
+        properties[key] = value
+      elsif Hash === value
+        if Hash === properties[key]
+          teacup_merge properties[key], value
+        elsif TrueClass === properties[key]
+          properties[key] = value
+        end
+      end
+    end
+    properties
   end
 
   # Merge definitions for 'frame' and orientation styles into one.

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -128,6 +128,7 @@ class UIView
       end
     end
     self.setNeedsDisplay
+    self.setNeedsLayout
   end
 
   def top_level_view

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -90,10 +90,10 @@ class UIView
         assign = :"#{key}="
         setter = ('set' + key.to_s.sub(/^./) {|c| c.capitalize}).to_sym
         if layer.respond_to?(assign)
-          NSLog "Setting layer.#{key} = #{value.inspect}"
+          # NSLog "Setting layer.#{key} = #{value.inspect}"
           layer.send(assign, value)
         elsif layer.respond_to?(setter)
-          NSLog "Calling layer(#{key}, #{value.inspect})"
+          # NSLog "Calling layer(#{key}, #{value.inspect})"
           layer.send(setter, value)
       else
         NSLog "Teacup WARN: Can't apply #{key} to #{self.layer.inspect}"
@@ -111,13 +111,17 @@ class UIView
       end
 
       if key == :title && UIButton === self
-        NSLog "Setting #{key} = #{value.inspect}, forState:UIControlStateNormal"
+        # NSLog "Setting #{key} = #{value.inspect}, forState:UIControlStateNormal"
         setTitle(value, forState: UIControlStateNormal)
+      # elsif key == :normal && UIButton === self
+      #   setImage(value, forState: UIControlStateNormal)
+      # elsif key == :highlighted && UIButton === self
+      #   setImage(value, forState: UIControlStateHighlighted)
       elsif assign and respond_to?(assign)
-        NSLog "Setting #{key} = #{value.inspect}"
+        # NSLog "Setting #{key} = #{value.inspect}"
         send(assign, value)
       elsif respondsToSelector(setter)
-        NSLog "Calling self(#{key}, #{value.inspect})"
+        # NSLog "Calling self(#{key}, #{value.inspect})"
         send(setter, value)
       else
         NSLog "Teacup WARN: Can't apply #{setter.inspect}#{assign and " or " + assign.inspect or ""} to #{self.inspect}"

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -47,7 +47,7 @@ class UIView
   end
 
   def restyle!(orientation=nil)
-    style(stylesheet.query(@stylename)) if @stylesheet
+    style(stylesheet.query(@stylename), orientation) if @stylesheet
     subviews.each{ |subview| subview.restyle!(orientation) }
   end
 

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -94,9 +94,13 @@ class UIView
     clean_properties properties, orientation
 
     # check for `:extends` and merge those in
-    while extended_properties = properties.delete(:extends)
-      clean_properties extended_properties, orientation
-      Teacup::merge_defaults!(properties, extended_properties)
+    while extended_properties_list = properties.delete(:extends)
+      extended_properties_list = [extended_properties_list] unless extended_properties_list.is_a? Array
+
+      extended_properties_list.each { |extended_properties|
+        clean_properties extended_properties, orientation
+        Teacup::merge_defaults!(properties, extended_properties)
+      }
     end
 
     if stylesheet

--- a/lib/teacup/z_core_extensions/ui_view_controller.rb
+++ b/lib/teacup/z_core_extensions/ui_view_controller.rb
@@ -138,30 +138,30 @@ class UIViewController
   # the teacup developers apologize for any inconvenience. :-)
   def autorotateToOrientation(orientation)
     if view.stylesheet and view.stylename
-      properties = view.stylesheet.query(view.stylename)
+      properties = view.stylesheet.query(view.stylename, self, orientation)
 
       # check for orientation-specific properties
       case orientation
       when UIInterfaceOrientationPortrait
         # portrait is "on" by default, must be turned off explicitly
-        if not properties.has_key? :portrait and not properties.has_key? :upside_up
+        if properties.supports?(:portrait) == nil and properties.supports?(:upside_up) == nil
           return true
         end
 
-        return true if properties[:portrait] or properties[:upside_up]
+        return (properties.supports?(:portrait) or properties.supports?(:upside_up))
       when UIInterfaceOrientationPortraitUpsideDown
         if UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone
           # iphone must have an explicit upside-down style, otherwise this returns
           # false
-          return true if properties[:upside_down]
+          return properties.supports?(:upside_down)
         else
           # ipad can just have a portrait style
-          return true if properties[:portrait] or properties[:upside_down]
+          return (properties.supports?(:portrait) or properties.supports?(:upside_down))
         end
       when UIInterfaceOrientationLandscapeLeft
-        return true if properties[:landscape] or properties[:landscape_left]
+        return (properties.supports?(:landscape) or properties.supports?(:landscape_left))
       when UIInterfaceOrientationLandscapeRight
-        return true if properties[:landscape] or properties[:landscape_right]
+        return (properties.supports?(:landscape) or properties.supports?(:landscape_right))
       end
 
       return false

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -16,7 +16,7 @@ describe "Application 'Scorrerest'" do
   it "should have a root view" do
     view_ctrlr_view = @view_ctrlr.view
     view_ctrlr_view.subviews.length.should == 1
-    view_ctrlr_view.subviews[0].class.should == UIView
+    view_ctrlr_view.subviews[0].class.should == CustomView
   end
 
   describe "view controller" do
@@ -66,6 +66,14 @@ describe "Application 'Scorrerest'" do
       @background.subviews[0].class.should == UILabel
       @background.subviews[1].class.should == UILabel
       @background.subviews[2].class.ancestors.include?(UIButton).should == true
+    end
+
+    it "should not have styles overridden by base classes" do
+      @background.alpha.should == 0.5
+    end
+
+    it "should have styles overridden orientation styles" do
+      @background.backgroundColor.should == UIColor.darkGrayColor
     end
 
     describe "background subviews" do
@@ -138,6 +146,14 @@ describe "Application 'Scorrerest'" do
       @background.frame.origin.y.should == 30
       @background.frame.size.width.should == 460
       @background.frame.size.height.should == 280
+      @background.backgroundColor.should == UIColor.lightGrayColor
+    end
+
+    it "should not have styles overridden by base classes" do
+      @background.alpha.should == 0.8
+    end
+
+    it "should have styles overridden orientation styles" do
       @background.backgroundColor.should == UIColor.lightGrayColor
     end
 

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -1,4 +1,4 @@
-describe "Application 'Scorrerest'" do
+describe "Application 'Teacup'" do
   before do
     UIDevice.currentDevice.beginGeneratingDeviceOrientationNotifications
     @app = UIApplication.sharedApplication

--- a/spec/style_spec.rb
+++ b/spec/style_spec.rb
@@ -1,0 +1,169 @@
+describe "Teacup::Style" do
+
+  it "should be equal to a Hash" do
+    Teacup::Style.new.should == {}
+  end
+
+  it "should act like a Hash" do
+    style = Teacup::Style.new
+    style[:key] = :value
+    style[:key].should == :value
+  end
+
+  it "should use orientation to override" do
+    style = Teacup::Style.new
+    style[:name] = :default
+    style[:landscape] = {
+      name: :landscape_name,
+    }
+    style[:portrait] = {
+      name: :portrait_name,
+    }
+    style[:upside_up] = {
+      name: :upside_up_name,
+    }
+    # no orientation
+    style.build()[:name].should == :default
+    # landscape
+    style.build(nil, UIInterfaceOrientationLandscapeLeft)[:name].should == :landscape_name
+    style.build(nil, UIInterfaceOrientationPortrait)[:name].should == :upside_up_name
+  end
+
+  it "should look in extends" do
+    sheet = Teacup::Stylesheet.new do
+      style :extended,
+        key: :value
+    end
+    sheet.query(:extended)[:key].should == :value
+
+    style = Teacup::Style.new
+    style.stylename = :self
+    style.stylesheet = sheet
+    style[:extends] = :extended
+    style.build()[:key].should == :value
+  end
+
+  it "should look in import" do
+    imported_sheet = Teacup::Stylesheet.new do
+      style :extended,
+        imported: :imported,
+        override: :overridden
+    end
+
+    sheet = Teacup::Stylesheet.new do
+      import imported_sheet
+
+      style :extended,
+        key: :value,
+        override: :override
+    end
+    sheet.query(:extended)[:key].should == :value
+    sheet.query(:extended)[:imported].should == :imported
+    sheet.query(:extended)[:override].should == :override
+  end
+
+  it 'should merge :extends properties' do
+    sheet = Teacup::Stylesheet.new do
+      style :style1,
+        a: 'a',
+        b: 'b'
+    end
+    style2 = Teacup::Style.new
+    style2.stylesheet = sheet
+    style2[:a] = 'A'
+    style2[:extends] = :style1
+
+    built = style2.build()
+    built[:a].should == 'A'
+    built[:b].should == 'b'
+  end
+
+  it 'should merge hashes' do
+    sheet = Teacup::Stylesheet.new do
+      style :style1,
+        layer: { borderWidth: 20, opacity: 0.5 }
+    end
+
+    style2 = Teacup::Style.new
+    style2.stylesheet = sheet
+    style2[:layer] = { borderWidth: 10 }
+    style2[:extends] = :style1
+
+    built = style2.build()
+    built[:layer][:opacity].should == 0.5
+    built[:layer][:borderWidth].should == 10
+  end
+
+  it 'should merge multiple extends' do
+    sheet = Teacup::Stylesheet.new do
+      style :style1,
+        layer: { borderWidth: 20 }
+      style :style2,
+        layer: { borderWidth: 10, opacity: 0.5 }
+    end
+
+    style3 = Teacup::Style.new
+    style3.stylesheet = sheet
+    style3[:extends] = [:style1, :style2]
+
+    built = style3.build()
+    built[:layer][:opacity].should == 0.5
+    built[:layer][:borderWidth].should == 20
+  end
+
+  it 'should merge and flatten orientation rules' do
+    sheet = Teacup::Stylesheet.new do
+      style :style1,
+        portrait: { text: "ignored", tag: 1 }
+    end
+
+    style2 = Teacup::Style.new
+    style2.stylesheet = sheet
+    style2[:portrait] = { text: "text" }
+    style2[:extends] = :style1
+
+    built = style2.build(nil, UIInterfaceOrientationPortrait)
+    built[:tag].should == 1
+    built[:text].should == "text"
+  end
+
+  it 'should respect precedence rules' do
+    sheet = Teacup::Stylesheet.new do
+      style :style1,
+        portrait: { text: "extended", tag: 1 }
+    end
+
+    style2 = Teacup::Style.new
+    style2.stylesheet = sheet
+    style2[:text] = "text"
+    style2[:extends] = :style1
+
+    built = style2.build(nil, UIInterfaceOrientationPortrait)
+    built[:tag].should == 1
+    built[:text].should == "text"
+  end
+
+  it 'should respect merge based on class inheritance' do
+    class Foo
+      attr_accessor :bar
+    end
+
+    class Bar < Foo
+      attr_accessor :baz
+    end
+
+    sheet = Teacup::Stylesheet.new do
+      style Foo,
+        bar: 'bar'
+    end
+
+    style = Teacup::Style.new
+    style.stylesheet = sheet
+    style[:baz] = 'baz'
+
+    built = style.build(Bar.new)
+    built[:bar].should == 'bar'
+    built[:baz].should == 'baz'
+  end
+
+end

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -88,8 +88,8 @@ describe "Teacup::Stylesheet" do
 
     end
 
-    it 'should union different properties' do
-      @stylesheet.query(:left_label)[:font].should == "IMPACT"
+    it 'should put extended properties into an "extends" Hash' do
+      @stylesheet.query(:left_label)[:extends][:font].should == "IMPACT"
       @stylesheet.query(:left_label)[:left].should == 100
     end
 
@@ -99,8 +99,10 @@ describe "Teacup::Stylesheet" do
 
     it 'should follow a chain of extends' do
       @stylesheet.query(:how_much)[:backgroundColor].should == :red
-      @stylesheet.query(:how_much)[:left] == 100
-      @stylesheet.query(:how_much)[:font] == "IMPACT"
+      @stylesheet.query(:how_much)[:extends][:backgroundColor].should == :green
+      @stylesheet.query(:how_much)[:extends][:extends][:backgroundColor].should == :blue
+      @stylesheet.query(:how_much)[:extends][:left] == 100
+      @stylesheet.query(:how_much)[:extends][:extends][:font] == "IMPACT"
     end
   end
 
@@ -241,18 +243,18 @@ describe "Teacup::Stylesheet" do
     it 'should give precedence to later imports' do
       stylesheet = Teacup::Stylesheet.new do
         import Teacup::Stylesheet.new{
-          style :label,
+          style :label_bla,
             text: "Imported first",
             backgroundColor: :blue
         }
 
         import Teacup::Stylesheet.new{
-          style :label,
+          style :label_bla,
             text: "Imported last"
         }
       end
-      stylesheet.query(:label)[:text].should == "Imported last"
-      stylesheet.query(:label)[:backgroundColor].should == :blue
+      stylesheet.query(:label_bla)[:text].should == "Imported last"
+      stylesheet.query(:label_bla)[:backgroundColor].should == :blue
     end
 
     it 'should give precedence to less-nested imports' do
@@ -289,7 +291,7 @@ describe "Teacup::Stylesheet" do
       end
 
       stylesheet.query(:my_textfield)[:text].should == "Imported"
-      stylesheet.query(:my_textfield)[:backgroundColor].should == :blue
+      stylesheet.query(:my_textfield)[:extends][:backgroundColor].should == :blue
       stylesheet.query(:my_textfield)[:borderRadius].should == 10
     end
   end

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -88,8 +88,8 @@ describe "Teacup::Stylesheet" do
 
     end
 
-    it 'should put extended properties into an "extends" Hash' do
-      @stylesheet.query(:left_label)[:extends][:font].should == "IMPACT"
+    it 'should put extended properties into an "extends" Array of Hashes' do
+      @stylesheet.query(:left_label)[:extends][0][:font].should == "IMPACT"
       @stylesheet.query(:left_label)[:left].should == 100
     end
 
@@ -99,10 +99,10 @@ describe "Teacup::Stylesheet" do
 
     it 'should follow a chain of extends' do
       @stylesheet.query(:how_much)[:backgroundColor].should == :red
-      @stylesheet.query(:how_much)[:extends][:backgroundColor].should == :green
-      @stylesheet.query(:how_much)[:extends][:extends][:backgroundColor].should == :blue
-      @stylesheet.query(:how_much)[:extends][:left] == 100
-      @stylesheet.query(:how_much)[:extends][:extends][:font] == "IMPACT"
+      @stylesheet.query(:how_much)[:extends][0][:backgroundColor].should == :green
+      @stylesheet.query(:how_much)[:extends][0][:extends][0][:backgroundColor].should == :blue
+      @stylesheet.query(:how_much)[:extends][0][:left] == 100
+      @stylesheet.query(:how_much)[:extends][0][:extends][0][:font] == "IMPACT"
     end
   end
 
@@ -291,7 +291,7 @@ describe "Teacup::Stylesheet" do
       end
 
       stylesheet.query(:my_textfield)[:text].should == "Imported"
-      stylesheet.query(:my_textfield)[:extends][:backgroundColor].should == :blue
+      stylesheet.query(:my_textfield)[:extends][0][:backgroundColor].should == :blue
       stylesheet.query(:my_textfield)[:borderRadius].should == 10
     end
 

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -311,8 +311,8 @@ describe "Teacup::Stylesheet" do
           }
       end
 
-      stylesheet.query(:my_textfield)[:opacity].should == 0.5
-      stylesheet.query(:my_textfield)[:borderRadius].should == 10
+      stylesheet.query(:my_textfield)[:layer][:opacity].should == 0.5
+      stylesheet.query(:my_textfield)[:layer][:borderRadius].should == 10
     end
   end
 end

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -294,5 +294,25 @@ describe "Teacup::Stylesheet" do
       stylesheet.query(:my_textfield)[:extends][:backgroundColor].should == :blue
       stylesheet.query(:my_textfield)[:borderRadius].should == 10
     end
+
+    it 'should import rules using a deep merge strategy' do
+      stylesheet = Teacup::Stylesheet.new do
+        import Teacup::Stylesheet.new{
+          style :my_textfield,
+            layer: {
+              borderRadius: 1,
+              opacity: 0.5
+            }
+        }
+
+        style :my_textfield,
+          layer: {
+            borderRadius: 10
+          }
+      end
+
+      stylesheet.query(:my_textfield)[:opacity].should == 0.5
+      stylesheet.query(:my_textfield)[:borderRadius].should == 10
+    end
   end
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -107,6 +107,12 @@ describe "Teacup::View" do
       @view.layer.borderWidth.should == 10
     end
 
+    it 'should merge multiple extends' do
+      @view.style({extends: [{layer: { borderWidth: 20 }}, {layer: { borderWidth: 10, opacity: 0.5 }}]}, UIInterfaceOrientationPortrait)
+      @view.layer.opacity.should == 0.5
+      @view.layer.borderWidth.should == 20
+    end
+
     it 'should merge and flatten orientation rules' do
       @view.style({portrait: {text: "text"}, extends: { portrait: { text: "ignored", tag: 1 } }}, UIInterfaceOrientationPortrait)
       @view.tag.should == 1

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -79,7 +79,7 @@ describe "Teacup::View" do
     end
 
     it 'should merge and flatten orientation rules' do
-      @view.style({portrait: {text: "text"}, extends: { portrait: { text: "extended", tag: 1 } }}, UIInterfaceOrientationPortrait)
+      @view.style({portrait: {text: "text"}, extends: { portrait: { text: "ignored", tag: 1 } }}, UIInterfaceOrientationPortrait)
       @view.tag.should == 1
       @view.text.should == "text"
     end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -66,6 +66,30 @@ describe "Teacup::View" do
       @view.layer.borderWidth.should == 10
     end
 
+    it 'should merge :extends properties' do
+      @view.style(text: "text", extends: { text: "extended", tag: 1 })
+      @view.tag.should == 1
+      @view.text.should == "text"
+    end
+
+    it 'should merge hashes' do
+      @view.style({layer: {borderWidth: 10}, extends: { layer: { borderWidth: 20, opacity: 0.5 } }}, UIInterfaceOrientationPortrait)
+      @view.layer.opacity.should == 0.5
+      @view.layer.borderWidth.should == 10
+    end
+
+    it 'should merge and flatten orientation rules' do
+      @view.style({portrait: {text: "text"}, extends: { portrait: { text: "extended", tag: 1 } }}, UIInterfaceOrientationPortrait)
+      @view.tag.should == 1
+      @view.text.should == "text"
+    end
+
+    it 'should respect precedence rules' do
+      @view.style({text: "text", extends: { portrait: { text: "extended", tag: 1 } }}, UIInterfaceOrientationPortrait)
+      @view.tag.should == 1
+      @view.text.should == "text"
+    end
+
     it 'should warn about unknown thingies' do
       @view.style(partyTime: :always)
     end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -1,4 +1,3 @@
-
 describe "Teacup::View" do
 
   before do
@@ -95,38 +94,8 @@ describe "Teacup::View" do
       @view.layer.borderWidth.should == 10
     end
 
-    it 'should merge :extends properties' do
-      @view.style(text: "text", extends: { text: "extended", tag: 1 })
-      @view.tag.should == 1
-      @view.text.should == "text"
-    end
-
-    it 'should merge hashes' do
-      @view.style({layer: {borderWidth: 10}, extends: { layer: { borderWidth: 20, opacity: 0.5 } }}, UIInterfaceOrientationPortrait)
-      @view.layer.opacity.should == 0.5
-      @view.layer.borderWidth.should == 10
-    end
-
-    it 'should merge multiple extends' do
-      @view.style({extends: [{layer: { borderWidth: 20 }}, {layer: { borderWidth: 10, opacity: 0.5 }}]}, UIInterfaceOrientationPortrait)
-      @view.layer.opacity.should == 0.5
-      @view.layer.borderWidth.should == 20
-    end
-
-    it 'should merge and flatten orientation rules' do
-      @view.style({portrait: {text: "text"}, extends: { portrait: { text: "ignored", tag: 1 } }}, UIInterfaceOrientationPortrait)
-      @view.tag.should == 1
-      @view.text.should == "text"
-    end
-
-    it 'should respect precedence rules' do
-      @view.style({text: "text", extends: { portrait: { text: "extended", tag: 1 } }}, UIInterfaceOrientationPortrait)
-      @view.tag.should == 1
-      @view.text.should == "text"
-    end
-
     it 'should warn about unknown thingies' do
-      @view.style(partyTime: :always)
+      @view.style(partyTime: :excellent)
     end
 
   end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -46,6 +46,35 @@ describe "Teacup::View" do
     end
   end
 
+  describe 'import' do
+    before do
+      @import_view = UIView.new
+
+      Teacup::Stylesheet.new :to_import do
+        style :view,
+          top: 20,
+          portrait: {
+            top: 30
+          }
+      end
+
+      @import_stylesheet = Teacup::Stylesheet.new do
+        import :to_import
+
+        style :view,
+          top: 40
+      end
+    end
+
+    it 'should always prefer more local styles' do
+      @import_view.stylename = :view
+      @import_view.stylesheet = @import_stylesheet
+
+      @import_view.restyle!(orientation=UIInterfaceOrientationPortrait)
+      @import_view.frame.origin.y.should == 40
+    end
+  end
+
   describe 'style' do
 
     it 'should assign any random property that works' do

--- a/teacup.gemspec
+++ b/teacup.gemspec
@@ -1,5 +1,4 @@
 require File.expand_path('../lib/teacup/version.rb', __FILE__)
-require File.expand_path('../lib/teacup/contributors.rb', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = 'teacup'

--- a/teacup.gemspec
+++ b/teacup.gemspec
@@ -3,25 +3,20 @@ require File.expand_path('../lib/teacup/contributors.rb', __FILE__)
 
 Gem::Specification.new do |gem|
 
-  gem.authors  = Teacup::CONTRIBUTORS
-  gem.description = <<-DESC
-  Teacup is a community-driven DSL for making CSS-like styling, and layouts for complex, and simple
-  iOS apps with RubyMotion.
-  
-  By aiming at making RubyMotion less tedious, Teacup makes RubyMotion feel like interface builder, and
-  work like a CSS stylesheet.
-  DESC
+  gem.authors  = ['the rubymotion community']
 
-  gem.summary = 'A community-driven DSL for creating user interfaces on the iphone.'
+  gem.description = <<-DESC
+Teacup is a community-driven DSL for making CSS-like styling, and layouts for
+complex and simple iOS apps with RubyMotion.
+
+By aiming at making RubyMotion less tedious, Teacup makes RubyMotion feel like
+interface builder, and work like a CSS stylesheet.
+DESC
+
+  gem.summary = 'A community-driven DSL for creating user interfaces on iOS.'
   gem.homepage = 'https://github.com/rubymotion/teacup'
 
-  gem.files   = %w(lib/teacup.rb
-                   lib/teacup/version.rb
-                   lib/teacup/contributors.rb
-                   lib/teacup/helpers/helpers.rb
-                   lib/teacup/style_sheet.rb)
-
-  gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  gem.files       = `git ls-files`.split($\)
   gem.test_files  = gem.files.grep(%r{^spec/})
 
   gem.name          = 'teacup'

--- a/teacup.gemspec
+++ b/teacup.gemspec
@@ -2,6 +2,8 @@ require File.expand_path('../lib/teacup/version.rb', __FILE__)
 require File.expand_path('../lib/teacup/contributors.rb', __FILE__)
 
 Gem::Specification.new do |gem|
+  gem.name          = 'teacup'
+  gem.version       = Teacup::VERSION
 
   gem.authors  = ['the rubymotion community']
 
@@ -17,11 +19,8 @@ DESC
   gem.homepage = 'https://github.com/rubymotion/teacup'
 
   gem.files       = `git ls-files`.split($\)
-  gem.test_files  = gem.files.grep(%r{^spec/})
-
-  gem.name          = 'teacup'
   gem.require_paths = ['lib']
-  gem.version       = Teacup::VERSION
+  gem.test_files  = gem.files.grep(%r{^spec/})
 
   gem.add_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
gemspec is up-to-date, and a little cleaner.  logging is handled using NSLog (since puts has had issues on devices? so i've heard).

fixes: the `assign` and `setter` methods are a little different, depending on whether the method matches `/^set[A-Z]/`, and `setter` uses `respondsToSelector` not `respond_to?`.

More dummy methods.

And most importantly, `require 'teacup'` after installing it will successfully include this gem.  huzzah!
