### PR TITLE
Fixes

### DIFF
--- a/app/controllers/first_controller.rb
+++ b/app/controllers/first_controller.rb
@@ -4,7 +4,7 @@ class FirstController < UIViewController
   stylesheet :first
 
   layout :root do
-    subview(UIView, :background) do
+    subview(CustomView, :background) do
       @welcome = subview(UILabel, :welcome)
       subview(UILabel, :footer)
       @button = subview(UIButton.buttonWithType(UIButtonTypeRoundedRect), :next_message)

--- a/app/styles/main_styles.rb
+++ b/app/styles/main_styles.rb
@@ -35,9 +35,21 @@ Teacup::Stylesheet.new(:first) do
     textColor:  UIColor.blueColor,
   })
 
+  style CustomView,
+    # for testing how styles override (this gets overridden by any property in
+    # a style block, regardless of whether it is in an orientation style)
+    portrait: {
+      alpha: 0.75
+    },
+    landscape: {
+      alpha: 0.75
+    }
+
   style(:background, {
+    alpha: 0.5,
     left: 10,
     top: 30,
+    backgroundColor:  UIColor.blackColor,
 
     portrait: {
       width:  300,
@@ -48,6 +60,7 @@ Teacup::Stylesheet.new(:first) do
     landscape: {
       width:  460,
       height: 280,
+      alpha: 0.8,
       backgroundColor:  UIColor.lightGrayColor,
     },
   })

--- a/app/views/custom_view.rb
+++ b/app/views/custom_view.rb
@@ -1,0 +1,4 @@
+
+class CustomView < UIView
+  # not very custom, is it!?
+end

--- a/lib/dummy.rb
+++ b/lib/dummy.rb
@@ -3,6 +3,15 @@ class DummyView < UIView
 
   def dummy
     setFrame(nil)
+    setOpaque(nil)
+  end
+
+end
+
+class DummyScrollView < UIScrollView
+
+  def dummy
+    setScrollEnabled(nil)
   end
 
 end

--- a/lib/dummy.rb
+++ b/lib/dummy.rb
@@ -14,6 +14,11 @@ class DummyLayer < CALayer
     setTransform(nil)
     setMasksToBounds(nil)
     setShadowOffset(nil)
+    setShadowOpacity(nil)
+    setShadowRadius(nil)
+    setShadowOffset(nil)
+    setShadowColor(nil)
+    setShadowPath(nil)
   end
 
 end

--- a/lib/teacup/merge_defaults.rb
+++ b/lib/teacup/merge_defaults.rb
@@ -1,0 +1,51 @@
+
+module Teacup
+  module_function
+
+  # Merges two Hashes.  This is similar to `Hash#merge`, except the values will
+  # be merged recursively (aka deep merge) when both values for a key are
+  # Hashes, and values for the *left* argument are preferred over values on the
+  # right.
+  #
+  # If you pass in a third argument, it will be acted upon directly instead of
+  # creating a new Hash.  Usually used with `merge_defaults!`, which merges values
+  # from `right` into `left`.
+  def merge_defaults(left, right, target={})
+    if target == left
+    elsif target == right
+    else
+    end
+
+    if target != left
+      left.each do |key, value|
+        if target.has_key? key and value.is_a?(Hash) and target[key].is_a?(Hash)
+          target[key] = Teacup::merge_defaults(target[key], value)
+        else
+          if value.is_a?(Hash)
+            # make a copy of the Hash
+            value = Teacup::merge_defaults!({}, value)
+          end
+          target[key] = value
+        end
+      end
+    end
+
+    right.each do |key, value|
+      if not target.has_key? key
+        if value.is_a?(Hash)
+          # make a copy of the Hash
+          value = Teacup::merge_defaults!({}, value)
+        end
+        target[key] = value
+      elsif value.is_a?(Hash) and left[key].is_a?(Hash)
+        target[key] = Teacup::merge_defaults(left[key], value, (left==target ? left[key] : {}))
+      end
+    end
+    target
+  end
+
+  # modifies left by passing it in as the `target`.
+  def merge_defaults!(left, right)
+    Teacup::merge_defaults(left, right, left)
+  end
+end

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -235,7 +235,7 @@ module Teacup
       imported.map do |name_or_stylesheet|
         if Teacup::Stylesheet === name_or_stylesheet
           name_or_stylesheet
-        elsif Teacup::Stylesheet.stylesheets.key? name_or_stylesheet
+        elsif Teacup::Stylesheet.stylesheets.has_key? name_or_stylesheet
           Teacup::Stylesheet.stylesheets[name_or_stylesheet]
         else
           raise "Teacup tried to import Stylesheet '#{name_or_stylesheet.inspect}' into Stylesheet[#{self.name}], but it didn't exist"

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -153,10 +153,11 @@ module Teacup
       this_rule = properties_for(stylename)
 
       if also_include = this_rule.delete(:extends)
-        query(also_include).update(this_rule)
-      else
-        this_rule
+        # we stick the extended Hash onto 'extends', which will get picked
+        # up by UIView#style, which handles precedence.
+        this_rule[:extends] = query(also_include)
       end
+      this_rule
     end
 
     # Add a set of properties for a given stylename or multiple stylenames.

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -208,6 +208,10 @@ module Teacup
     def properties_for(stylename, so_far={}, seen={})
       return so_far if seen[self]
 
+      # the block handed to Stylesheet#new is not run immediately - it is run
+      # the first time the stylesheet is queried.  This fixes bugs related to
+      # some resources (fonts) not available when the application is first
+      # started.
       if @block
         instance_eval &@block
         @block = nil

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -152,10 +152,11 @@ module Teacup
     def query(stylename)
       this_rule = properties_for(stylename)
 
-      if also_include = this_rule.delete(:extends)
+      if also_includes = this_rule.delete(:extends)
+        also_includes = [also_includes] unless also_includes.is_a? Array
         # we stick the extended Hash onto 'extends', which will get picked
         # up by UIView#style, which handles precedence.
-        this_rule[:extends] = query(also_include)
+        this_rule[:extends] = also_includes.map {|also_include| query(also_include) }
       end
       this_rule
     end

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -243,7 +243,7 @@ module Teacup
         elsif Teacup::Stylesheet.stylesheets.has_key? name_or_stylesheet
           Teacup::Stylesheet.stylesheets[name_or_stylesheet]
         else
-          raise "Teacup tried to import Stylesheet '#{name_or_stylesheet.inspect}' into Stylesheet[#{self.name}], but it didn't exist"
+          raise "Teacup tried to import Stylesheet #{name_or_stylesheet.inspect} into Stylesheet[#{self.name.inspect}], but it didn't exist"
         end
       end
     end

--- a/lib/teacup/stylesheet.rb
+++ b/lib/teacup/stylesheet.rb
@@ -173,7 +173,7 @@ module Teacup
     #       title: "Continue!",
     #       top: 50
     #   end
-    def style(*queries, &block)
+    def style(*queries)
       properties = {}
 
       # if the last argument is a Hash, include it
@@ -181,7 +181,7 @@ module Teacup
 
       # iterate over the style names and assign properties
       queries.each do |stylename|
-        styles[stylename].update(properties)
+        Teacup::merge_defaults(properties, styles[stylename], styles[stylename])
       end
     end
 
@@ -223,7 +223,7 @@ module Teacup
         stylesheet.properties_for(stylename, so_far, seen)
       end
 
-      so_far.update(styles[stylename])
+      Teacup::merge_defaults styles[stylename], so_far, so_far
     end
 
     # The list of Stylesheets or names that have been imported into this one.

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -148,19 +148,14 @@ class UIView
     self.setNeedsDisplay
   end
 
-  # merges two Hashs.  When the value of the "lesser" Hash is a Hash, it will be
-  # merged into the "greater" Hash, or it will be assigned if the value is True
-  # or not assigned at all.
+  # merges two Hashes.  This is similar to `Hash#update`, except the values will
+  # be merged recursively (aka deep merge) when both values for a key are Hashes
   def teacup_merge properties, extended_properties
     extended_properties.each do |key, value|
       if not properties.has_key? key
         properties[key] = value
-      elsif Hash === value
-        if Hash === properties[key]
-          teacup_merge properties[key], value
-        elsif TrueClass === properties[key]
-          properties[key] = value
-        end
+      elsif Hash === value and Hash === properties[key]
+        teacup_merge properties[key], value
       end
     end
     properties

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -96,14 +96,14 @@ class UIView
     # check for `:extends` and merge those in
     while extended_properties = properties.delete(:extends)
       clean_properties extended_properties, orientation
-      teacup_merge properties, extended_properties
+      Teacup::merge_defaults!(properties, extended_properties)
     end
 
     if stylesheet
       self.class.ancestors.each do |ancestor|
         if extended_properties = stylesheet.query(ancestor)
           clean_properties extended_properties, orientation
-          teacup_merge properties, extended_properties
+          Teacup::merge_defaults!(properties, extended_properties)
         end
       end
     end
@@ -146,19 +146,6 @@ class UIView
       end
     end
     self.setNeedsDisplay
-  end
-
-  # merges two Hashes.  This is similar to `Hash#update`, except the values will
-  # be merged recursively (aka deep merge) when both values for a key are Hashes
-  def teacup_merge properties, extended_properties
-    extended_properties.each do |key, value|
-      if not properties.has_key? key
-        properties[key] = value
-      elsif Hash === value and Hash === properties[key]
-        teacup_merge properties[key], value
-      end
-    end
-    properties
   end
 
   # Merge definitions for 'frame' and orientation styles into one.

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -85,44 +85,22 @@ class UIView
   #
   # @param Hash  the properties to set.
   def style(properties, orientation=nil)
+    # the order of assigning to properties is muy importante here.  We want
+    # the orientation styles to override what is in the "default" styles, but
+    # when we import styles from ancestors, we don't want those to override what
+    # we already set.
+
+    # convert top/left/width/height and orientation properties
+    clean_properties properties, orientation
+
     if stylesheet
       self.class.ancestors.each do |ancestor|
         if default_properties = stylesheet.query(ancestor)
+          clean_properties default_properties, orientation
           properties = default_properties.merge properties
         end
       end
     end
-
-    # orientation-specific properties
-    portrait = properties.delete(:portrait)
-    upside_up = properties.delete(:upside_up)
-    upside_down = properties.delete(:upside_down)
-
-    landscape = properties.delete(:landscape)
-    landscape_left = properties.delete(:landscape_left)
-    landscape_right = properties.delete(:landscape_right)
-
-    if orientation.nil?
-      orientation = UIApplication.sharedApplication.statusBarOrientation
-    end
-
-    case orientation
-    when UIInterfaceOrientationPortrait
-      properties = portrait.update(properties) if Hash === portrait
-      properties = upside_up.update(properties) if Hash === upside_up
-    when UIInterfaceOrientationPortraitUpsideDown
-      properties = portrait.update(properties) if Hash === portrait
-      properties = upside_down.update(properties) if Hash === upside_down
-    when UIInterfaceOrientationLandscapeLeft
-      properties = landscape.update(properties) if Hash === landscape
-      properties = landscape_left.update(properties) if Hash === landscape_left
-    when UIInterfaceOrientationLandscapeRight
-      properties = landscape.update(properties) if Hash === landscape
-      properties = landscape_right.update(properties) if Hash === landscape_right
-    end
-
-    # convert top/left/width/height to frame values
-    clean_properties properties
 
     if layer_properties = properties.delete(:layer)
       layer_properties.each do |key, value|
@@ -164,7 +142,7 @@ class UIView
     self.setNeedsDisplay
   end
 
-  # merge definitions for 'frame' into one.
+  # Merge definitions for 'frame' and orientation styles into one.
   #
   # To support 'extends' more nicely it's convenient to split left, top, width
   # and height out of frame. Unfortunately that means we have to write ugly
@@ -174,17 +152,51 @@ class UIView
   #
   # @param Hash
   # @return Hash
-  def clean_properties(properties)
-    return unless [:frame, :left, :top, :width, :height].any?(&properties.method(:key?))
+  def clean_properties(properties, orientation=nil)
+    if [:portrait, :upside_up, :upside_down,
+        :landscape, :landscape_left, :landscape_right
+        ].any?(&properties.method(:has_key?))
+      # orientation-specific properties
+      portrait = properties.delete(:portrait)
+      upside_up = properties.delete(:upside_up)
+      upside_down = properties.delete(:upside_down)
 
-    frame = properties.delete(:frame) || self.frame
+      landscape = properties.delete(:landscape)
+      landscape_left = properties.delete(:landscape_left)
+      landscape_right = properties.delete(:landscape_right)
 
-    frame[0][0] = properties.delete(:left) || frame[0][0]
-    frame[0][1] = properties.delete(:top) || frame[0][1]
-    frame[1][0] = properties.delete(:width) || frame[1][0]
-    frame[1][1] = properties.delete(:height) || frame[1][1]
+      if orientation.nil?
+        orientation = UIApplication.sharedApplication.statusBarOrientation
+      end
 
-    properties[:frame] = frame
+      case orientation
+      when UIInterfaceOrientationPortrait
+        properties.update(portrait) if Hash === portrait
+        properties.update(upside_up) if Hash === upside_up
+      when UIInterfaceOrientationPortraitUpsideDown
+        properties.update(portrait) if Hash === portrait
+        properties.update(upside_down) if Hash === upside_down
+      when UIInterfaceOrientationLandscapeLeft
+        properties.update(landscape) if Hash === landscape
+        properties.update(landscape_left) if Hash === landscape_left
+      when UIInterfaceOrientationLandscapeRight
+        properties.update(landscape) if Hash === landscape
+        properties.update(landscape_right) if Hash === landscape_right
+      end
+    end
+
+    # this has to come *after* orientation merges
+    if [:frame, :left, :top, :width, :height].any?(&properties.method(:has_key?))
+      frame = properties.delete(:frame) || self.frame
+
+      frame[0][0] = properties.delete(:left) || frame[0][0]
+      frame[0][1] = properties.delete(:top) || frame[0][1]
+      frame[1][0] = properties.delete(:width) || frame[1][0]
+      frame[1][1] = properties.delete(:height) || frame[1][1]
+
+      properties[:frame] = frame
+    end
+
     properties
   end
 

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -93,11 +93,17 @@ class UIView
     # convert top/left/width/height and orientation properties
     clean_properties properties, orientation
 
+    # check for `:extends` and merge those in
+    while extended_properties = properties.delete(:extends)
+      clean_properties extended_properties, orientation
+      teacup_merge properties, extended_properties
+    end
+
     if stylesheet
       self.class.ancestors.each do |ancestor|
-        if default_properties = stylesheet.query(ancestor)
-          clean_properties default_properties, orientation
-          properties = default_properties.merge properties
+        if extended_properties = stylesheet.query(ancestor)
+          clean_properties extended_properties, orientation
+          teacup_merge properties, extended_properties
         end
       end
     end
@@ -140,6 +146,11 @@ class UIView
       end
     end
     self.setNeedsDisplay
+  end
+
+  # merges two Hashs - it's a deep_merge.
+  def teacup_merge properties, extended_properties
+    extended_properties.update(properties)
   end
 
   # Merge definitions for 'frame' and orientation styles into one.

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -141,18 +141,24 @@ class UIView
     end
 
     properties.each do |key, value|
-      assign = :"#{key}="
-      setter = ('set' + key.to_s.sub(/^./) {|c| c.capitalize}).to_sym
+      if key =~ /^set[A-Z]/
+        assign = nil
+        setter = key.to_s + ':'
+      else
+        assign = :"#{key}="
+        setter = 'set' + key.to_s.sub(/^./) {|c| c.capitalize} + ':'
+      end
+
       if key == :title && UIButton === self
         setTitle(value, forState: UIControlStateNormal)
-      elsif respond_to?(assign)
+      elsif assign and respond_to?(assign)
         # puts "Setting #{key} = #{value.inspect}"
         send(assign, value)
-      elsif respond_to?(setter)
+      elsif respondsToSelector(setter)
         # puts "Calling self(#{key}, #{value.inspect})"
         send(setter, value)
       else
-        puts "Teacup WARN: Can't apply #{key} to #{self.inspect}"
+        puts "Teacup WARN: Can't apply #{setter.inspect}#{assign and " or " + assign.inspect or ""} to #{self.inspect}"
       end
     end
     self.setNeedsDisplay

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -108,17 +108,17 @@ class UIView
 
     case orientation
     when UIInterfaceOrientationPortrait
-      properties.update(portrait) if Hash === portrait
-      properties.update(upside_up) if Hash === upside_up
+      properties = portrait.update(properties) if Hash === portrait
+      properties = upside_up.update(properties) if Hash === upside_up
     when UIInterfaceOrientationPortraitUpsideDown
-      properties.update(portrait) if Hash === portrait
-      properties.update(upside_down) if Hash === upside_down
+      properties = portrait.update(properties) if Hash === portrait
+      properties = upside_down.update(properties) if Hash === upside_down
     when UIInterfaceOrientationLandscapeLeft
-      properties.update(landscape) if Hash === landscape
-      properties.update(landscape_left) if Hash === landscape_left
+      properties = landscape.update(properties) if Hash === landscape
+      properties = landscape_left.update(properties) if Hash === landscape_left
     when UIInterfaceOrientationLandscapeRight
-      properties.update(landscape) if Hash === landscape
-      properties.update(landscape_right) if Hash === landscape_right
+      properties = landscape.update(properties) if Hash === landscape
+      properties = landscape_right.update(properties) if Hash === landscape_right
     end
 
     # convert top/left/width/height to frame values

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -148,9 +148,22 @@ class UIView
     self.setNeedsDisplay
   end
 
-  # merges two Hashs - it's a deep_merge.
+  # merges two Hashs.  When the value of the "lesser" Hash is a Hash, it will be
+  # merged into the "greater" Hash, or it will be assigned if the value is True
+  # or not assigned at all.
   def teacup_merge properties, extended_properties
-    extended_properties.update(properties)
+    extended_properties.each do |key, value|
+      if not properties.has_key? key
+        properties[key] = value
+      elsif Hash === value
+        if Hash === properties[key]
+          teacup_merge properties[key], value
+        elsif TrueClass === properties[key]
+          properties[key] = value
+        end
+      end
+    end
+    properties
   end
 
   # Merge definitions for 'frame' and orientation styles into one.

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -47,7 +47,7 @@ class UIView
   end
 
   def restyle!(orientation=nil)
-    style(stylesheet.query(@stylename)) if @stylesheet
+    style(stylesheet.query(@stylename), orientation) if @stylesheet
     subviews.each{ |subview| subview.restyle!(orientation) }
   end
 

--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -94,9 +94,13 @@ class UIView
     clean_properties properties, orientation
 
     # check for `:extends` and merge those in
-    while extended_properties = properties.delete(:extends)
-      clean_properties extended_properties, orientation
-      Teacup::merge_defaults!(properties, extended_properties)
+    while extended_properties_list = properties.delete(:extends)
+      extended_properties_list = [extended_properties_list] unless extended_properties_list.is_a? Array
+
+      extended_properties_list.each { |extended_properties|
+        clean_properties extended_properties, orientation
+        Teacup::merge_defaults!(properties, extended_properties)
+      }
     end
 
     if stylesheet

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -16,7 +16,7 @@ describe "Application 'Scorrerest'" do
   it "should have a root view" do
     view_ctrlr_view = @view_ctrlr.view
     view_ctrlr_view.subviews.length.should == 1
-    view_ctrlr_view.subviews[0].class.should == UIView
+    view_ctrlr_view.subviews[0].class.should == CustomView
   end
 
   describe "view controller" do
@@ -66,6 +66,14 @@ describe "Application 'Scorrerest'" do
       @background.subviews[0].class.should == UILabel
       @background.subviews[1].class.should == UILabel
       @background.subviews[2].class.ancestors.include?(UIButton).should == true
+    end
+
+    it "should not have styles overridden by base classes" do
+      @background.alpha.should == 0.5
+    end
+
+    it "should have styles overridden orientation styles" do
+      @background.backgroundColor.should == UIColor.darkGrayColor
     end
 
     describe "background subviews" do
@@ -138,6 +146,14 @@ describe "Application 'Scorrerest'" do
       @background.frame.origin.y.should == 30
       @background.frame.size.width.should == 460
       @background.frame.size.height.should == 280
+      @background.backgroundColor.should == UIColor.lightGrayColor
+    end
+
+    it "should not have styles overridden by base classes" do
+      @background.alpha.should == 0.8
+    end
+
+    it "should have styles overridden orientation styles" do
       @background.backgroundColor.should == UIColor.lightGrayColor
     end
 

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -88,8 +88,8 @@ describe "Teacup::Stylesheet" do
 
     end
 
-    it 'should union different properties' do
-      @stylesheet.query(:left_label)[:font].should == "IMPACT"
+    it 'should put extended properties into an "extends" Hash' do
+      @stylesheet.query(:left_label)[:extends][:font].should == "IMPACT"
       @stylesheet.query(:left_label)[:left].should == 100
     end
 
@@ -99,8 +99,10 @@ describe "Teacup::Stylesheet" do
 
     it 'should follow a chain of extends' do
       @stylesheet.query(:how_much)[:backgroundColor].should == :red
-      @stylesheet.query(:how_much)[:left] == 100
-      @stylesheet.query(:how_much)[:font] == "IMPACT"
+      @stylesheet.query(:how_much)[:extends][:backgroundColor].should == :green
+      @stylesheet.query(:how_much)[:extends][:extends][:backgroundColor].should == :blue
+      @stylesheet.query(:how_much)[:extends][:left] == 100
+      @stylesheet.query(:how_much)[:extends][:extends][:font] == "IMPACT"
     end
   end
 
@@ -241,18 +243,18 @@ describe "Teacup::Stylesheet" do
     it 'should give precedence to later imports' do
       stylesheet = Teacup::Stylesheet.new do
         import Teacup::Stylesheet.new{
-          style :label,
+          style :label_bla,
             text: "Imported first",
             backgroundColor: :blue
         }
 
         import Teacup::Stylesheet.new{
-          style :label,
+          style :label_bla,
             text: "Imported last"
         }
       end
-      stylesheet.query(:label)[:text].should == "Imported last"
-      stylesheet.query(:label)[:backgroundColor].should == :blue
+      stylesheet.query(:label_bla)[:text].should == "Imported last"
+      stylesheet.query(:label_bla)[:backgroundColor].should == :blue
     end
 
     it 'should give precedence to less-nested imports' do
@@ -289,7 +291,7 @@ describe "Teacup::Stylesheet" do
       end
 
       stylesheet.query(:my_textfield)[:text].should == "Imported"
-      stylesheet.query(:my_textfield)[:backgroundColor].should == :blue
+      stylesheet.query(:my_textfield)[:extends][:backgroundColor].should == :blue
       stylesheet.query(:my_textfield)[:borderRadius].should == 10
     end
   end

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -88,8 +88,8 @@ describe "Teacup::Stylesheet" do
 
     end
 
-    it 'should put extended properties into an "extends" Hash' do
-      @stylesheet.query(:left_label)[:extends][:font].should == "IMPACT"
+    it 'should put extended properties into an "extends" Array of Hashes' do
+      @stylesheet.query(:left_label)[:extends][0][:font].should == "IMPACT"
       @stylesheet.query(:left_label)[:left].should == 100
     end
 
@@ -99,10 +99,10 @@ describe "Teacup::Stylesheet" do
 
     it 'should follow a chain of extends' do
       @stylesheet.query(:how_much)[:backgroundColor].should == :red
-      @stylesheet.query(:how_much)[:extends][:backgroundColor].should == :green
-      @stylesheet.query(:how_much)[:extends][:extends][:backgroundColor].should == :blue
-      @stylesheet.query(:how_much)[:extends][:left] == 100
-      @stylesheet.query(:how_much)[:extends][:extends][:font] == "IMPACT"
+      @stylesheet.query(:how_much)[:extends][0][:backgroundColor].should == :green
+      @stylesheet.query(:how_much)[:extends][0][:extends][0][:backgroundColor].should == :blue
+      @stylesheet.query(:how_much)[:extends][0][:left] == 100
+      @stylesheet.query(:how_much)[:extends][0][:extends][0][:font] == "IMPACT"
     end
   end
 
@@ -291,7 +291,7 @@ describe "Teacup::Stylesheet" do
       end
 
       stylesheet.query(:my_textfield)[:text].should == "Imported"
-      stylesheet.query(:my_textfield)[:extends][:backgroundColor].should == :blue
+      stylesheet.query(:my_textfield)[:extends][0][:backgroundColor].should == :blue
       stylesheet.query(:my_textfield)[:borderRadius].should == 10
     end
 

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -311,8 +311,8 @@ describe "Teacup::Stylesheet" do
           }
       end
 
-      stylesheet.query(:my_textfield)[:opacity].should == 0.5
-      stylesheet.query(:my_textfield)[:borderRadius].should == 10
+      stylesheet.query(:my_textfield)[:layer][:opacity].should == 0.5
+      stylesheet.query(:my_textfield)[:layer][:borderRadius].should == 10
     end
   end
 end

--- a/spec/stylesheet_spec.rb
+++ b/spec/stylesheet_spec.rb
@@ -294,5 +294,25 @@ describe "Teacup::Stylesheet" do
       stylesheet.query(:my_textfield)[:extends][:backgroundColor].should == :blue
       stylesheet.query(:my_textfield)[:borderRadius].should == 10
     end
+
+    it 'should import rules using a deep merge strategy' do
+      stylesheet = Teacup::Stylesheet.new do
+        import Teacup::Stylesheet.new{
+          style :my_textfield,
+            layer: {
+              borderRadius: 1,
+              opacity: 0.5
+            }
+        }
+
+        style :my_textfield,
+          layer: {
+            borderRadius: 10
+          }
+      end
+
+      stylesheet.query(:my_textfield)[:opacity].should == 0.5
+      stylesheet.query(:my_textfield)[:borderRadius].should == 10
+    end
   end
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -107,6 +107,12 @@ describe "Teacup::View" do
       @view.layer.borderWidth.should == 10
     end
 
+    it 'should merge multiple extends' do
+      @view.style({extends: [{layer: { borderWidth: 20 }}, {layer: { borderWidth: 10, opacity: 0.5 }}]}, UIInterfaceOrientationPortrait)
+      @view.layer.opacity.should == 0.5
+      @view.layer.borderWidth.should == 20
+    end
+
     it 'should merge and flatten orientation rules' do
       @view.style({portrait: {text: "text"}, extends: { portrait: { text: "ignored", tag: 1 } }}, UIInterfaceOrientationPortrait)
       @view.tag.should == 1

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -79,7 +79,7 @@ describe "Teacup::View" do
     end
 
     it 'should merge and flatten orientation rules' do
-      @view.style({portrait: {text: "text"}, extends: { portrait: { text: "extended", tag: 1 } }}, UIInterfaceOrientationPortrait)
+      @view.style({portrait: {text: "text"}, extends: { portrait: { text: "ignored", tag: 1 } }}, UIInterfaceOrientationPortrait)
       @view.tag.should == 1
       @view.text.should == "text"
     end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -66,6 +66,30 @@ describe "Teacup::View" do
       @view.layer.borderWidth.should == 10
     end
 
+    it 'should merge :extends properties' do
+      @view.style(text: "text", extends: { text: "extended", tag: 1 })
+      @view.tag.should == 1
+      @view.text.should == "text"
+    end
+
+    it 'should merge hashes' do
+      @view.style({layer: {borderWidth: 10}, extends: { layer: { borderWidth: 20, opacity: 0.5 } }}, UIInterfaceOrientationPortrait)
+      @view.layer.opacity.should == 0.5
+      @view.layer.borderWidth.should == 10
+    end
+
+    it 'should merge and flatten orientation rules' do
+      @view.style({portrait: {text: "text"}, extends: { portrait: { text: "extended", tag: 1 } }}, UIInterfaceOrientationPortrait)
+      @view.tag.should == 1
+      @view.text.should == "text"
+    end
+
+    it 'should respect precedence rules' do
+      @view.style({text: "text", extends: { portrait: { text: "extended", tag: 1 } }}, UIInterfaceOrientationPortrait)
+      @view.tag.should == 1
+      @view.text.should == "text"
+    end
+
     it 'should warn about unknown thingies' do
       @view.style(partyTime: :always)
     end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -46,6 +46,35 @@ describe "Teacup::View" do
     end
   end
 
+  describe 'import' do
+    before do
+      @import_view = UIView.new
+
+      Teacup::Stylesheet.new :to_import do
+        style :view,
+          top: 20,
+          portrait: {
+            top: 30
+          }
+      end
+
+      @import_stylesheet = Teacup::Stylesheet.new do
+        import :to_import
+
+        style :view,
+          top: 40
+      end
+    end
+
+    it 'should always prefer more local styles' do
+      @import_view.stylename = :view
+      @import_view.stylesheet = @import_stylesheet
+
+      @import_view.restyle!(orientation=UIInterfaceOrientationPortrait)
+      @import_view.frame.origin.y.should == 40
+    end
+  end
+
   describe 'style' do
 
     it 'should assign any random property that works' do


### PR DESCRIPTION
Small fix: `respond_to?` is the wrong method sometimes - prototyped methods don't seem to get picked up.  `respondsToSelector:` returns the correct value.

Bigger bug: fixed how styles get overridden.  Here was the situation:

``` ruby
style UIButton,
  portrait: {
    width: 200
  }

style :my_button,
  width: 150
```

`:my_button` was getting set to `width: 200`, because `portrait` was overriding the "default".  The fix was to move the orientation code into `clean_properties`, and call `clean_properties` before merging the classes (before `self.class.ancestors.each...`).  It's a big gnarly diff, but check out the tests - they kind of make it clear what is fixed (and the tests _pass_, so **there** :wink:)
