### PR TITLE
calculate relative widths

### DIFF
--- a/lib/teacup/z_core_extensions/z_handlers.rb
+++ b/lib/teacup/z_core_extensions/z_handlers.rb
@@ -1,51 +1,71 @@
+module Teacup
+  module_function
+  def calculate(view, dimension, percent)
+    if percent.is_a? Proc
+      view.instance_exec(&percent)
+    elsif percent.is_a? String and percent[-1] == '%'
+      percent = percent[0...-1].to_f / 100.0
+
+      case dimension
+      when :width
+        CGRectGetWidth(view.superview.bounds) * percent
+      when :height
+        CGRectGetHeight(view.superview.bounds) * percent
+      end
+    else
+      percent
+    end
+  end
+end
+
 ##|
 ##|  UIView.frame
 ##|
 Teacup.handler UIView, :left, :x { |x|
   f = self.frame
-  f.origin.x = x
+  f.origin.x = Teacup::calculate(self, :width, x)
   self.frame = f
 }
 
 Teacup.handler UIView, :right { |r|
   f = self.frame
-  f.origin.x = r - f.size.width
+  f.origin.x = Teacup::calculate(self, :width, r) - f.size.width
   self.frame = f
 }
 
 Teacup.handler UIView, :center_x, :middle_x { |x|
   c = self.center
-  c.x = x
+  c.x = Teacup::calculate(self, :width, x)
   self.center = c
 }
 
 Teacup.handler UIView, :top, :y { |y|
   f = self.frame
-  f.origin.y = y
+  f.origin.y = Teacup::calculate(self, :height, y)
   self.frame = f
 }
 
 Teacup.handler UIView, :bottom { |b|
   f = self.frame
-  f.origin.y = b - f.size.height
+  f.origin.y = Teacup::calculate(self, :height, b) - f.size.height
   self.frame = f
 }
 
 Teacup.handler UIView, :center_y, :middle_y { |y|
   c = self.center
-  c.y = y
+  c.y = Teacup::calculate(self, :height, y)
   self.center = c
 }
 
 Teacup.handler UIView, :width { |w|
   f = self.frame
-  f.size.width = w
+  f.size.width = Teacup::calculate(self, :width, w)
   self.frame = f
 }
 
 Teacup.handler UIView, :height { |h|
   f = self.frame
-  f.size.height = h
+  f.size.height = Teacup::calculate(self, :height, h)
   self.frame = f
 }
 
@@ -59,10 +79,12 @@ Teacup.handler UIView, :size { |size|
   # odd... if I changed these to .is_a?, weird errors happen.  Use ===
   if Symbol === size && size == :full
     if self.superview
-      size = Size(self.superview.bounds.size)
+      size = self.superview.bounds.size
     else
       size = self.frame.size
     end
+  elsif Array === size
+    size = [Teacup::calculate(self, :width, size[0]), Teacup::calculate(self, :height, size[1])]
   end
   f = self.frame
   f.size = size
@@ -73,10 +95,20 @@ Teacup.handler UIView, :frame { |frame|
   # odd... if I changed these to .is_a?, weird errors happen.  Use ===
   if Symbol === frame && frame == :full
     if self.superview
-      frame = Rect(self.superview.bounds)
+      frame = self.superview.bounds
     else
       frame = self.frame
     end
+  elsif Array === frame && frame.length == 4
+    frame = [
+        [Teacup::calculate(self, :width, frame[0]), Teacup::calculate(self, :height, frame[1])],
+        [Teacup::calculate(self, :width, frame[2]), Teacup::calculate(self, :height, frame[3])]
+      ]
+  elsif Array === frame && frame.length == 2
+    frame = [
+        [Teacup::calculate(self, :width, frame[0][0]), Teacup::calculate(self, :height, frame[0][1])],
+        [Teacup::calculate(self, :width, frame[1][0]), Teacup::calculate(self, :height, frame[1][1])]
+      ]
   end
   self.frame = frame
 }


### PR DESCRIPTION
based on [this discussion](https://github.com/rubymotion/teacup/issues/49), I implemented a `Teacup.calculate` method that can accept a number (which it returns untouched), a percent (e.g. `'100%'`) or a `Proc`, which is handed the superview as the only argument, and called using `instance_exec`, so `self` is the view being styled.
