### PR TITLE
Fix dependency issue with z_handlers.rb / handler.rb

### DIFF
--- a/lib/teacup/calculations.rb
+++ b/lib/teacup/calculations.rb
@@ -1,0 +1,19 @@
+module Teacup
+  module_function
+  def calculate(view, dimension, percent)
+    if percent.is_a? Proc
+      view.instance_exec(&percent)
+    elsif percent.is_a? String and percent[-1] == '%'
+      percent = percent[0...-1].to_f / 100.0
+
+      case dimension
+      when :width
+        CGRectGetWidth(view.superview.bounds) * percent
+      when :height
+        CGRectGetHeight(view.superview.bounds) * percent
+      end
+    else
+      percent
+    end
+  end
+end

--- a/lib/teacup/z_core_extensions/z_handlers.rb
+++ b/lib/teacup/z_core_extensions/z_handlers.rb
@@ -1,23 +1,3 @@
-module Teacup
-  module_function
-  def calculate(view, dimension, percent)
-    if percent.is_a? Proc
-      view.instance_exec(&percent)
-    elsif percent.is_a? String and percent[-1] == '%'
-      percent = percent[0...-1].to_f / 100.0
-
-      case dimension
-      when :width
-        CGRectGetWidth(view.superview.bounds) * percent
-      when :height
-        CGRectGetHeight(view.superview.bounds) * percent
-      end
-    else
-      percent
-    end
-  end
-end
-
 ##|
 ##|  UIView.frame
 ##|


### PR DESCRIPTION
I've been getting problems with recent versions of teacup (de36e232 was ok, master is not) with the following error:

```
Terminating app due to uncaught exception 'NoMethodError', reason: 'undefined method `handler' for Teacup:Class (NoMethodError)
```

It looks like this is because z_core_extensions/z_handlers.rb was being loaded before handler.rb, even though z_handlers.rb needs handler.rb to be already loaded (since it calls `Teacup.handler`)

My best guess as to why this happens is because z_handlers.rb reopens the Teacup module to define the calculate method. I think that because rubymotion sees lots of files that define/reopen the Teacup module it doesn't know which one comes first and, by luck or otherwise is choosing z_handlers.rb as the file that defines the Teacup module and so loads it early on.

This patch dodges the issue by moving the definition of the calculate method into its own file, so that Rubymotion doesn't feel the need to load z_handlers.rb early.

I don't know whether this is something rubymotion could be detecting, but until then it fixes the issue for me
