### PR TITLE
Fix broken UIView#animate_to_style method

### DIFF
--- a/lib/teacup/z_core_extensions/ui_view.rb
+++ b/lib/teacup/z_core_extensions/ui_view.rb
@@ -205,7 +205,7 @@ class UIView
     UIView.beginAnimations(nil, context: nil)
     UIView.setAnimationDuration(style[:duration]) if style[:duration]
     UIView.setAnimationCurve(style[:curve]) if style[:curve]
-    UIView.setAnimationDelay(options[:delay]) if options[:delay]
+    UIView.setAnimationDelay(style[:delay]) if style[:delay]
     style(style)
     UIView.commitAnimations
   end


### PR DESCRIPTION
The local variable "options" does not exist. This is most probably the result of a copy and paste from the "animate_to_stylename" method.
