### PR TITLE
Found another need in the dummy.rb

### DIFF
--- a/lib/dummy.rb
+++ b/lib/dummy.rb
@@ -89,3 +89,10 @@ private
     setOn(true)
   end
 end
+
+class DummyUIImageView < UIImageView
+private
+  def dummy
+    setUserInteractionEnabled(nil)
+  end
+end


### PR DESCRIPTION
Got this in a personal project, so adding to dummy.rb

Fixed it for me.

```
Objective-C stub for message `setUserInteractionEnabled:' type `v@:c' not precompiled. Make sure you properly link with the framework or library that defines this message.
(main)> *** simulator session ended with error: Error Domain=DTiPhoneSimulatorErrorDomain Code=1 "The simulated application quit." UserInfo=0x100506b90 {NSLocalizedDescription=The simulated application quit., DTiPhoneSimulatorUnderlyingErrorCodeKey=-1}
rake aborted!
Command failed with status (1): [DYLD_FRAMEWORK_PATH="/Applications/Xcode.a...]
```
