### PR TITLE
Fix #69 Workaround RubyMotion dependency detection

### DIFF
--- a/lib/teacup/z_core_extensions/ui_view_controller.rb
+++ b/lib/teacup/z_core_extensions/ui_view_controller.rb
@@ -256,13 +256,8 @@ class UIViewController
 end
 
 
-module Teacup
-
-module_function
-  def get_subviews(target)
-    [target] + target.subviews.map { |subview|
-      get_subviews(subview).select{ |v| v.stylename }
-    }.flatten
-  end
-
+def Teacup.get_subviews(target)
+  [target] + target.subviews.map { |subview|
+    get_subviews(subview).select{ |v| v.stylename }
+  }.flatten
 end


### PR DESCRIPTION
By defining a singleton method directly on Teacup, rather than
opening the Teacup module to define it within, RubyMotion's
dependency detection is prevented from diagnosing a dependency
cycle between layout.rb and ui_view_controller.rb.

See issue #69.
