### PR TITLE
updated source for Gemfile

### DIFF
--- a/samples/Hai/Gemfile
+++ b/samples/Hai/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'teacup', :path => '../..'

--- a/samples/Hai/Gemfile.lock
+++ b/samples/Hai/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    teacup (1.3.2)
+    teacup (1.3.3)
 
 GEM
   remote: https://rubygems.org/

--- a/samples/Hai/Gemfile.lock
+++ b/samples/Hai/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     teacup (1.3.2)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
 
 PLATFORMS

--- a/samples/OnePage/Gemfile.lock
+++ b/samples/OnePage/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    geomotion (0.12.1)
+    rake (10.0.4)
+    sugarcube (0.20.18)
+    sweettea (0.5.6)
+      rake
+      sugarcube
+      teacup
+    teacup (1.3.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  geomotion
+  rake
+  sugarcube
+  sweettea
+  teacup


### PR DESCRIPTION
The Gemfile for one of the samples listed the source as :rubygems.

I also updated Gemfile.lock where it referred to an old version of teacup.  I did this in a separate commit in case you didn't want this.   (Personally, though, I think it's better to remove the Gemfile.lock from the repo, since these are just samples, not production apps where it's important to ensure tight control over versions of dependent gems.)
