### PR TITLE
Add rake as test, dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+group :test, :development do
+  gem 'rake'
+end
+
 gem 'motion-layout'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     motion-layout (0.0.1)
+    rake (0.9.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   motion-layout
+  rake
   teacup!


### PR DESCRIPTION
This fixes the broken Travis CI build:
https://travis-ci.org/rubymotion/teacup/builds/7448079

Which was caused by a lack of rake in the gemfile while using bundle exec:

```
bundle exec rake spec
/Users/travis/.rvm/gems/ruby-1.9.3-p392@global/gems/bundler-1.3.5/lib/bundler/rubygems_integration.rb:214:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /Users/travis/.rvm/gems/ruby-1.9.3-p392@global/bin/rake:18:in `<main>'
    from /Users/travis/.rvm/gems/ruby-1.9.3-p392/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/travis/.rvm/gems/ruby-1.9.3-p392/bin/ruby_noexec_wrapper:14:in `<main>'
```
