### PR TITLE
Only use first level subviews for motion-layout

### DIFF
--- a/app/controllers/motion_layout_controller.rb
+++ b/app/controllers/motion_layout_controller.rb
@@ -2,11 +2,13 @@ class MotionLayoutController < UIViewController
   attr :label1
   attr :label2
   attr :label3
+  attr :container
 
   layout :root do
     @label1 = subview(UILabel, :label1, text: 'label1')
     @label2 = subview(UILabel, :label2, text: 'label2')
     @label3 = subview(UILabel, :label3, text: 'label3')
+    @container = subview(CustomContainer, :container)
   end
 
   def layoutDidLoad
@@ -14,8 +16,20 @@ class MotionLayoutController < UIViewController
       metrics "margin" => 20, "top" => 100
       horizontal '|-margin-[label1]-margin-[label2(==label1)]-margin-|'
       horizontal '|-margin-[label3]-margin-|'
+      horizontal '|-margin-[container]-margin-|'
       vertical '|-top-[label1]'
       vertical '|-220-[label3(==label1)]'
+      vertical '|-320-[container(==label1)]'
+    end
+  end
+
+  class CustomContainer < UIView
+    attr :label4
+
+    def init
+      super.tap do
+        @label4 = subview(UILabel, :label4, text: 'label4')
+      end
     end
   end
 

--- a/lib/teacup/teacup_util.rb
+++ b/lib/teacup/teacup_util.rb
@@ -4,11 +4,7 @@ module Teacup
   # Returns all the subviews of `target` that have a stylename.  `target` is not
   # included in the list.  Used by the motion-layout integration in layout.rb.
   def get_styled_subviews(target)
-    retval = target.subviews.select { |v| v.stylename }
-    retval.concat(target.subviews.map do |subview|
-      get_styled_subviews(subview)
-    end)
-    retval.flatten
+    target.subviews.select { |v| v.stylename }
   end
 
   def to_instance(class_or_instance)

--- a/spec/ios/motion_layout_spec.rb
+++ b/spec/ios/motion_layout_spec.rb
@@ -39,6 +39,14 @@ describe "MotionLayout" do
       label3_top.should == 220
     end
 
+    it 'should have label4 at 320' do
+      frame = controller.container.label4.frame
+      frame = controller.container.convertRect(frame, toView: controller.view)
+      label4_top = CGRectGetMinY(frame)
+      label4_top.should == 320
+    end
+
+
   end
 
 end


### PR DESCRIPTION
- Motion Layout adds all passed views as subviews of the current view,
- so only the first level subviews should be passed as a parameter.
- This fixes an issue where a subview of a subview was moving to the
- parent view
