### PR TITLE
Reset constraints - forget the previously set constraints

### DIFF
--- a/lib/teacup/teacup_view.rb
+++ b/lib/teacup/teacup_view.rb
@@ -308,6 +308,13 @@ module Teacup
       Teacup.apply_hash self, properties
     end
 
+    def reset_constraints
+      @teacup_constraints = nil
+      subviews.each do |subview|
+        subview.reset_constraints
+      end
+    end
+
     def add_uniq_constraints(constraint)
       @teacup_constraints ||= {}
 

--- a/spec/ios/view_spec.rb
+++ b/spec/ios/view_spec.rb
@@ -21,7 +21,32 @@ describe "Teacup::View" do
 
       style :new_style,
         text: 'new style'
+
+      style :constrained,
+        constraints: [
+          [:full]
+        ]
+
     end
+  end
+
+  describe 'reset_constraints' do
+
+    before do
+      @outer = UIView.new
+      @outer.addSubview @view
+    end
+
+    it "forgets the list of constraints that may have been set" do
+      @view.stylesheet = @stylesheet
+      @view.add_style_class :constrained
+      @view.apply_constraints
+      @view.constraints.should.not.be.empty
+      @view.reset_constraints
+      @view.apply_constraints
+      @view.constraints.should.be.empty
+    end
+
   end
 
   describe 'stylename=' do


### PR DESCRIPTION
I found this useful while working through a tutorial on "intermediate" auto layout techniques. Basically I want to forget / reset all of the previously set constraints and then apply new styles with a new set. Normally in iOS you would simply clear the UIView's constraints collection, but I realized that teacup keeps its own cache of previously set constraints.

For ease of use (!), I also clear the teacup constraints recursively to allow the user to decide where in the tree they (i.e. I) want to reset.

I don't know if this goes against the intent of this great library (as I am new to teacup), so please feel free to suggest any better alternative behavior.
