### PR TITLE
Added the ability to "inherit" constraints when extending a style

### DIFF
--- a/spec/ios/constraints_spec.rb
+++ b/spec/ios/constraints_spec.rb
@@ -129,3 +129,43 @@ describe 'Using constraints in landscape' do
   end
 
 end
+
+describe 'extends merges constraints' do
+  before do
+    Teacup::Stylesheet.new(:ipad) do
+      style :button,
+        constraints: [
+          constrain_height(22),
+          constrain_top(0)
+        ]
+
+      style :tall_button, extends: :button,
+        constraints: [
+          constrain_height(44),
+        ]
+    end
+  end
+
+  it 'should not affect "base class" style' do
+    ipad_stylesheet = Teacup::Stylesheet[:ipad]
+    button_style = ipad_stylesheet.query(:button)
+    button_style[:constraints].size.should == 2
+    height_constraint = button_style[:constraints].first
+    top_constraint = button_style[:constraints].last
+    height_constraint.attribute.should == Teacup::Constraint::Attributes[:height]
+    height_constraint.constant.should == 22
+    top_constraint.attribute.should == Teacup::Constraint::Attributes[:top]
+    top_constraint.constant.should == 0
+  end
+
+  it 'should merge constraints when extending styles' do
+    ipad_stylesheet = Teacup::Stylesheet[:ipad]
+    tall_button_style = ipad_stylesheet.query(:tall_button)
+    height_constraint = tall_button_style[:constraints].first
+    height_constraint.attribute.should == Teacup::Constraint::Attributes[:height]
+    height_constraint.constant.should == 44
+    top_constraint = tall_button_style[:constraints].last
+    top_constraint.attribute.should == Teacup::Constraint::Attributes[:top]
+    top_constraint.constant.should == 0
+  end
+end


### PR DESCRIPTION
If you define these styles

``` ruby
Teacup::Stylesheet.new(:ipad) do
  style :button,
    constraints: [
      constrain_height(22),
      constrain_top(0)
    ]

  style :tall_button, extends: :button,
    constraints: [
      constrain_height(44),
    ]
end
```

`:tall_button` will be `constrain_height(44)` and `constrain_top(0)`

The logic ensures that only one constraint for an attribute will be applied in the new style

It is not perfect:  if you use a symbol in the base style such as `:top_left` and `constraints_top(8)` in the extended style both will exist incompatibly.

To get this working I had to make the Teacup merge_defaults module aware of constraints, but I could not think of any other way to do this.
