### PR TITLE
Defer to using #slice over [N..Nx] ranges until ruby motion memory leak is fixed

### DIFF
--- a/lib/teacup/calculations.rb
+++ b/lib/teacup/calculations.rb
@@ -5,8 +5,8 @@ module Teacup
       view.instance_exec(&amount)
     elsif amount.is_a?(String) && amount.include?('%')
       location = amount.index '%'
-      offset = amount[(location+1)..-1].gsub(' ', '').to_f
-      percent = amount[0...location].to_f / 100.0
+      offset = amount.slice(location+1, amount.size).gsub(' ', '').to_f
+      percent = amount.slice(0, location).to_f / 100.0
 
       case dimension
       when :width


### PR DESCRIPTION
This pull request is a simple change that use #slice over range slicing until ranges are not leaked by RubyMotion.
