### PR TITLE
Round to the nearest point when doing layout calculations

### DIFF
--- a/lib/teacup/calculations.rb
+++ b/lib/teacup/calculations.rb
@@ -10,9 +10,9 @@ module Teacup
 
       case dimension
       when :width
-        view.superview.bounds.size.width * percent + offset
+        (view.superview.bounds.size.width * percent + offset).round
       when :height
-        view.superview.bounds.size.height * percent + offset
+        (view.superview.bounds.size.height * percent + offset).round
       else
         raise "Unknown dimension #{dimension}"
       end

--- a/spec/ios/calculations_spec.rb
+++ b/spec/ios/calculations_spec.rb
@@ -1,10 +1,16 @@
 class Viewish
   def superview
-    @superview ||= Viewish.new
+    @superview ||= self.class.new
   end
 
   def bounds
     CGRect.new([0, 0,], [100, 44])
+  end
+end
+
+class IrregularBounds < Viewish
+  def bounds
+    CGRect.new([0, 0], [101, 43])
   end
 end
 
@@ -29,6 +35,11 @@ describe 'Teacup.calculate' do
 
   it 'should return percents with :height' do
     Teacup.calculate(Viewish.new, :height, '50%').should == 22
+  end
+
+  it "should round to the nearest point" do
+    Teacup.calculate(IrregularBounds.new, :height, '25%').should == 11
+    Teacup.calculate(IrregularBounds.new, :width, '25%').should == 25
   end
 
   describe 'should return percents with offset' do


### PR DESCRIPTION
This will avoid partial pixel results where the height, width, or offsets are "sub-pixel" values like 11.25.
