### PR TITLE
Replaced identity with transform_layer.identity

### DIFF
--- a/samples/ios/AutoLayout/lib/styles/base.rb
+++ b/samples/ios/AutoLayout/lib/styles/base.rb
@@ -16,7 +16,7 @@ Teacup::Stylesheet.new :base do
     shadowColor: UIColor.blackColor,
     textAlignment: UITextAlignmentCenter,
     layer: {
-      transform: identity,
+      transform: transform_layer.identity,
       shadowRadius: 20,
       shadowOpacity: 0.5,
       masksToBounds: false


### PR DESCRIPTION
The Stylesheet method `identity` is deprecated, use `transform_layer.identity` instead
