### PR TITLE
Add identifier to constraints

### DIFF
--- a/lib/teacup/constraint.rb
+++ b/lib/teacup/constraint.rb
@@ -8,6 +8,7 @@ module Teacup
     attr_accessor :multiplier
     attr_accessor :constant
     attr_accessor :priority
+    attr_accessor :identifier
 
     if defined? NSLayoutRelationEqual
       Priorities = {
@@ -187,6 +188,13 @@ module Teacup
       self
     end
 
+    def identifier(identifier=nil)
+      return @identifier if identifier.nil?
+
+      self.identifier = identifier
+      self
+    end
+
     def copy
       copy = self.class.new(self.target, self.attribute)
       copy.relationship = self.relationship
@@ -195,6 +203,7 @@ module Teacup
       copy.multiplier = self.multiplier
       copy.constant = self.constant
       copy.priority = self.priority
+      copy.identifier = self.identifier
       copy
     end
 
@@ -220,6 +229,7 @@ module Teacup
                                    constant: self.constant
                                            )
       nsconstraint.priority = priority_lookup(self.priority)
+      nsconstraint.setIdentifier(self.identifier) if self.identifier
       return nsconstraint
     end
 


### PR DESCRIPTION
Add identifier as a configurable option.

```
constraint_height(40).identifier("my_height")
```

use like this (console example)

```
a(25).get_ns_constraints.select{|c| c.identifier == "height"}.first
```

Weird unrelated fact, the a(25).constraints is always [](blank array) and does not contain the constraints.

This way constraints can be programmatically looked up. Unfortunately changing them dynamically does not work because the get_ns_constrains does not list the constraints by reference :(
