### PR TITLE
Safely check if teacup_next_responder weakref is still alive

### DIFF
--- a/lib/teacup/layout.rb
+++ b/lib/teacup/layout.rb
@@ -150,7 +150,7 @@ module Teacup
       # teacup_next_responder assigned, it's because another object is already
       # responsible for managing the view's stylesheet.
       if view.teacup_next_responder.nil? && view.is_a?(Layout)
-        view.teacup_next_responder = WeakRef.new(self)
+        view.teacup_next_responder = self
       end
 
       if block_given?

--- a/lib/teacup/teacup_view.rb
+++ b/lib/teacup/teacup_view.rb
@@ -24,6 +24,17 @@ module Teacup
       self.subviews || []
     end
 
+    def teacup_next_responder=(layout)
+      @_has_next_responder = true
+      @teacup_next_responder = WeakRef.new(layout)
+    end
+
+    def teacup_next_responder
+      if @_has_next_responder && @teacup_next_responder.weakref_alive?
+        @teacup_next_responder
+      end
+    end
+
     # Alter the stylename of this view.
     #
     # This will cause new styles to be applied from the stylesheet.
@@ -107,8 +118,8 @@ module Teacup
       # any views created there to the custom class (could be a controller, could
       # be any class that includes Teacup::Layout).  That responder is checked
       # next, but only if it wouldn't result in a circular loop.
-      if ! retval && @teacup_next_responder && teacup_next_responder != self
-        retval = @teacup_next_responder.stylesheet
+      if ! retval && teacup_next_responder && teacup_next_responder != self
+        retval = teacup_next_responder.stylesheet
       end
 
       # lastly, go up the chain; either a controller or superview


### PR DESCRIPTION
We've been getting some WeakRef::RefError crash reports.  I've come up with a solution.  It is not the most elegant one, but does solve the problem.

WeakRefs are nice, but you can't do anything with them beside check if they are alive if they are no more.  You cannot even check if they exist.  This solves that by setting a flag to know if we have one.

I could not find anywhere that nils it out, so I believe this is sufficient.  
